### PR TITLE
Fix project load failure

### DIFF
--- a/BabySmash.csproj
+++ b/BabySmash.csproj
@@ -361,7 +361,7 @@
   </Target>
   -->
   
-  <!---- THIS IS WHERE I ACTUALLY RELEASE IT TO PRODUCTION -->
+  <!-- THIS IS WHERE I ACTUALLY RELEASE IT TO PRODUCTION -->
   <!--<Target Name="BeforePublish">
     <Exec Command="&quot;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Bin\signtool.exe&quot; sign /f &quot;$(ProjectDir)\private.pfx&quot; /p PASSWORD /v &quot;$(ProjectDir)obj\$(ConfigurationName)\$(TargetFileName)&quot;" />
   </Target>-->


### PR DESCRIPTION
Fixed the following error:
BabySmash.csproj : error  : The project file could not be loaded. An XML comment cannot contain '--', and '-' cannot be the last character. Line 364, position 7.