### PR TITLE
Move Wordlist to User's My Documents folder

### DIFF
--- a/Controller.cs
+++ b/Controller.cs
@@ -41,7 +41,7 @@ namespace BabySmash
         private Queue<Shape> ellipsesQueue = new Queue<Shape>();
         private Dictionary<string, List<UserControl>> figuresUserControlQueue = new Dictionary<string, List<UserControl>>();
         private ApplicationDeployment deployment = null;
-        private WordFinder wordFinder = new WordFinder("Words.txt");
+        private WordFinder wordFinder = new WordFinder("BabySmashWords.txt");
 
         /// <summary>Prevents a default instance of the Controller class from being created.</summary>
         private Controller() { }

--- a/WordFinder.cs
+++ b/WordFinder.cs
@@ -23,14 +23,14 @@ namespace BabySmash
         public WordFinder(string wordsFilePath)
         {
             // File path provided should be relative to our running location, so combine for full path safety.
-            string dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string dir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             wordsFilePath = Path.Combine(dir, wordsFilePath);
 
             // Bail if the source word file is not found.
             if (!File.Exists(wordsFilePath))
             {
-                // Source word file was not found; place a 'words.txt' file next to BabySmash.exe to enable combining 
-                // letters into typed words. Some common names may work too (but successful OS speech synth may vary).
+                //Create the file for the user so they can start adding their own words
+                System.IO.File.Create(wordsFilePath);
                 return;
             }
 


### PR DESCRIPTION
Should resolve issue #7 
- Created an empty word list if one isn't found. It seems you can not have clickonce to write a file out to a separate directory.
- Also renamed the Word list to make it more descriptive to the end user. 
