### PR TITLE
Added german translation

### DIFF
--- a/Resources/Strings/de-DE.json
+++ b/Resources/Strings/de-DE.json
@@ -1,0 +1,21 @@
+﻿{
+	"Circle": "Kreis",
+	"Oval": "Oval",
+	"Rectangle": "Rechteck",
+	"Hexagon": "Sechseck",
+	"Trapezoid": "Trapez",
+	"Star": "Stern",
+	"Square": "Viereck",
+	"Triangle": "Dreieck",
+	"Heart": "Herz",
+
+	"Red": "Rotes",
+	"Blue": "Blaues",
+	"Yellow": "Gelbes",
+	"Green": "Grünes",
+	"Purple": "Lilanes",
+	"Pink": "Pinkes",
+	"Orange": "Oranges",
+	"Tan": "Braunes",
+	"Gray": "Graues"
+}


### PR DESCRIPTION
Pretty straight forward, only thing funky is the translation for circle would need another adjective case. Ideally it would be `Roter Kreis` instead of `Rotes Kreis` but I see no quick way of fixing this.

I think I also recognized a design flaw with the work this is based uppon. It might not work for people in other german speaking countries which are not in germany. Due to using the locale `de-DE` instead of just the language `de`

Anyway this is a start.