### PR TITLE
Fixed a few pixels of the Windows 10 taskbar displaying below the window

### DIFF
--- a/Controller.cs
+++ b/Controller.cs
@@ -127,6 +127,7 @@ namespace BabySmash
                     Width = s.WorkingArea.Width,
                     Height = s.WorkingArea.Height,
                     WindowStyle = WindowStyle.None,
+                    ResizeMode = ResizeMode.NoResize,
                     Topmost = true,
                     AllowsTransparency = Settings.Default.TransparentBackground,
                     Background = (Settings.Default.TransparentBackground ? new SolidColorBrush(Color.FromArgb(1, 0, 0, 0)) : Brushes.WhiteSmoke),


### PR DESCRIPTION
I fixed a few pixels of the Windows 10 taskbar displaying below the window (fixes #11). This was not tested with ClickOnce (since I couldn't figure out how to get that to work locally).