### PR TITLE
Improve mouse trail removal on multi-monitor setups

### DIFF
--- a/Controller.cs
+++ b/Controller.cs
@@ -613,7 +613,12 @@ namespace BabySmash
             if (ellipsesQueue.Count > 30) //this is arbitrary
             {
                 Shape shapeToRemove = ellipsesQueue.Dequeue();
-                main.mouseDragCanvas.Children.Remove(shapeToRemove);
+
+                // Remove this shape from all connected monitors
+                foreach (MainWindow window in windows)
+                {
+                    window.mouseDragCanvas.Children.Remove(shapeToRemove);
+                }
             }
         }
 


### PR DESCRIPTION
Currently, mouse trails become permanently affixed to windows when trails are alternately drawn beyond the 30 shape depth on alternating windows.

Over time, an intrepid mouse smasher is left with a bunch of mouse dots that just won't go away...

PR changes logic to evaluate the mouse shape container for eligible removal candidate across all MainWindow instances.