### PR TITLE
Support char display according to current keyboard layout (multiple keyboard languages)

### DIFF
--- a/Controller.cs
+++ b/Controller.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Deployment.Application;
@@ -242,7 +242,10 @@ namespace BabySmash
         public static extern bool GetKeyboardState(byte[] lpKeyState);
 
         [DllImport("user32.dll")]
-        public static extern uint MapVirtualKey(uint uCode, MapType uMapType);
+        public static extern uint MapVirtualKeyEx(uint uCode, MapType uMapType, IntPtr dwhkl);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetKeyboardLayout(int idThread);
 
         private static char TryGetLetter(Key key)
         {
@@ -252,7 +255,8 @@ namespace BabySmash
             byte[] keyboardState = new byte[256];
             GetKeyboardState(keyboardState);
 
-            uint scanCode = MapVirtualKey((uint)virtualKey, MapType.MAPVK_VK_TO_VSC);
+            IntPtr hkl = GetKeyboardLayout(0);
+            uint scanCode = MapVirtualKeyEx((uint)virtualKey, MapType.MAPVK_VK_TO_VSC, hkl);
             StringBuilder stringBuilder = new StringBuilder(2);
 
             int result = ToUnicode((uint)virtualKey, scanCode, keyboardState, stringBuilder, stringBuilder.Capacity, 0);


### PR DESCRIPTION
This small change will allow the display of chars according to the current keyboard layout, so if I work for example with an English/Hebrew keyboard, pressing ALT+SHIFT will change the chars displayed from the English Alphabet to the Hebrew Alphabet.