### PR TITLE
Add ability to override letters/numbers in resource to fix Canadian Zed

### DIFF
--- a/BabySmash.csproj
+++ b/BabySmash.csproj
@@ -46,6 +46,9 @@
     <None Update="Resources\Strings\en-EN.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Strings\en-CA.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Sounds\babylaugh.wav" />

--- a/Controller.cs
+++ b/Controller.cs
@@ -341,7 +341,7 @@ namespace BabySmash
             {
                 if (template.Letter != null && template.Letter.Length == 1 && Char.IsLetterOrDigit(template.Letter[0]))
                 {
-                    SpeakString(template.Letter);
+                    SpeakString(GetLocalizedString(template.Letter));
                 }
                 else
                 {

--- a/Resources/Strings/en-CA.json
+++ b/Resources/Strings/en-CA.json
@@ -1,0 +1,23 @@
+﻿{
+	"Circle": "Circle",
+	"Oval": "Oval",
+	"Rectangle": "Rectangle",
+	"Hexagon": "Hexagon",
+	"Trapezoid": "Trapezoid",
+	"Star": "Star",
+	"Square": "Square",
+	"Triangle": "Triangle",
+	"Heart": "Heart",
+
+	"Red": "Red",
+	"Blue": "Blue",
+	"Yellow": "Yellow",
+	"Green": "Green",
+	"Purple": "Purple",
+	"Pink": "Pink",
+	"Orange": "Orange",
+	"Tan": "Tan",
+	"Gray": "Gray",
+
+	"Z": "Zed"
+}


### PR DESCRIPTION
Canadian English TTS voices don't pronounce the letter Z as "Zed" as it should.

This change allows individual letters/numbers to be overridden in resources files, and adds an en-CA resource file to fix this pronunciation.

Takes advantage of the fact that `GetLocalizedString` will return the provided key if no match is found.