### PR TITLE
Support for pt-PT (Portuguese language, Portugal country "variation")

### DIFF
--- a/Resources/Strings/pt-PT.json
+++ b/Resources/Strings/pt-PT.json
@@ -1,0 +1,21 @@
+﻿{
+	"Circle": "Círculo",
+	"Oval": "Oval",
+	"Rectangle": "Retângulo",
+	"Hexagon": "Hexágono",
+	"Trapezoid": "Trapézio",
+	"Star": "Estrela",
+	"Square": "Quadrado",
+	"Triangle": "Triângulo",
+	"Heart": "Coração",
+
+	"Red": "Vermelho",
+	"Blue": "Azul",
+	"Yellow": "Amarelo",
+	"Green": "Verde",
+	"Purple": "Roxo",
+	"Pink": "Rosa",
+	"Orange": "Laranja",
+	"Tan": "Beje",
+	"Gray": "Cinza"
+}


### PR DESCRIPTION
This is part 1 of PR, including string resources for translation of shapes and colors

To whoever doesn't want to wait for next release or manually build the project:

1. Within your BabySmash _directory_ (or next to `BabySmash.exe` if you're using the _single file archive_), create a `Resources\Strings` (note: two folders, nested)
2. Download `pt-PT.json` (included in this PR) inside `Strings` folder

A related _glitch_ was identified, in [`PlaySound`](/shanselman/babysmash/blob/3257f6a98b3dc3d1351d7c2aeb48e482412c2a3e/Controller.cs#L402), where the reading is hard-coded to `<color> <shape>` order; in Portuguese, that will by default be the reverse `<shape> <color>`; guessing that a parameter stating the order will be enough, possibly as part of string resources &mdash; Question:
**Is there any known language that is dynamic regarding the shape-color ordering?**
A follow-up might be added to this PR ("part 2") or as separate PR if this is reviewed/merged in the meantime.