### PR TITLE
Add WinGet submission workflow

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -1,0 +1,157 @@
+name: Winget Submit
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to submit, for example v4.1.0
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
+    runs-on: windows-latest
+
+    env:
+      PACKAGE_ID: Hanselman.BabySmash
+      INSTALLER_ASSET: BabySmash-Setup.exe
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve release
+        shell: pwsh
+        run: |
+          $tag = if ("${{ github.event_name }}" -eq "release") {
+            "${{ github.event.release.tag_name }}"
+          } else {
+            "${{ inputs.tag }}"
+          }
+
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw "A release tag is required."
+          }
+
+          $version = $tag.TrimStart("v")
+          "TAG=$tag" >> $env:GITHUB_ENV
+          "VERSION=$version" >> $env:GITHUB_ENV
+          "RELEASE_URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> $env:GITHUB_ENV
+
+      - name: Download release asset
+        shell: pwsh
+        run: |
+          $baseUrl = "https://github.com/${{ github.repository }}/releases/download/$env:TAG"
+          $installerUrl = "$baseUrl/$env:INSTALLER_ASSET"
+          $installerPath = Join-Path ".winget-assets" $env:INSTALLER_ASSET
+
+          New-Item -ItemType Directory -Path ".winget-assets" -Force | Out-Null
+          Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath
+          $hash = (Get-FileHash -Algorithm SHA256 -Path $installerPath).Hash
+
+          "INSTALLER_URL=$installerUrl" >> $env:GITHUB_ENV
+          "INSTALLER_SHA256=$hash" >> $env:GITHUB_ENV
+
+      - name: Create manifest
+        shell: pwsh
+        run: |
+          $manifestRoot = Join-Path "winget-manifest" "manifests/h/Hanselman/BabySmash/$env:VERSION"
+          New-Item -ItemType Directory -Path $manifestRoot -Force | Out-Null
+
+          $release = gh release view $env:TAG --repo $env:GITHUB_REPOSITORY --json publishedAt | ConvertFrom-Json
+          $releaseDate = ([DateTime]$release.publishedAt).ToUniversalTime().ToString("yyyy-MM-dd")
+
+          @"
+          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+          PackageIdentifier: $env:PACKAGE_ID
+          PackageVersion: $env:VERSION
+          DefaultLocale: en-US
+          ManifestType: version
+          ManifestVersion: 1.10.0
+          "@ -replace "^[ \t]{10}", "" | Set-Content -Path (Join-Path $manifestRoot "$env:PACKAGE_ID.yaml") -Encoding utf8NoBOM
+
+          @"
+          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+          PackageIdentifier: $env:PACKAGE_ID
+          PackageVersion: $env:VERSION
+          PackageLocale: en-US
+          Publisher: Scott Hanselman
+          PublisherUrl: https://www.hanselman.com/
+          PublisherSupportUrl: https://github.com/$env:GITHUB_REPOSITORY/issues
+          Author: Scott Hanselman
+          PackageName: BabySmash!
+          PackageUrl: https://github.com/$env:GITHUB_REPOSITORY
+          License: MIT
+          LicenseUrl: https://github.com/$env:GITHUB_REPOSITORY/blob/main/LICENSE
+          Copyright: Copyright (c) 2015 Scott Hanselman
+          ShortDescription: A game for babies who like to bang on the keyboard.
+          Description: As babies or children smash on the keyboard, colored shapes, letters and numbers appear on the screen and are spoken aloud to help with letter and number recognition.
+          Moniker: babysmash
+          Tags:
+          - baby
+          - game
+          - kids
+          - keyboard
+          - toddler
+          ReleaseNotesUrl: $env:RELEASE_URL
+          ManifestType: defaultLocale
+          ManifestVersion: 1.10.0
+          "@ -replace "^[ \t]{10}", "" | Set-Content -Path (Join-Path $manifestRoot "$env:PACKAGE_ID.locale.en-US.yaml") -Encoding utf8NoBOM
+
+          @"
+          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+          PackageIdentifier: $env:PACKAGE_ID
+          PackageVersion: $env:VERSION
+          InstallerType: inno
+          Scope: user
+          UpgradeBehavior: install
+          Installers:
+          - Architecture: x64
+            InstallerUrl: $env:INSTALLER_URL
+            InstallerSha256: $env:INSTALLER_SHA256
+            ReleaseDate: $releaseDate
+          ManifestType: installer
+          ManifestVersion: 1.10.0
+          "@ -replace "^[ \t]{10}", "" | Set-Content -Path (Join-Path $manifestRoot "$env:PACKAGE_ID.installer.yaml") -Encoding utf8NoBOM
+
+          "MANIFEST_ROOT=$manifestRoot" >> $env:GITHUB_ENV
+
+      - name: Validate manifest
+        shell: pwsh
+        run: |
+          if (Get-Command winget -ErrorAction SilentlyContinue) {
+            winget validate --manifest $env:MANIFEST_ROOT
+          } else {
+            Write-Warning "winget is not available on this runner; skipping local manifest validation."
+          }
+
+      - name: Setup .NET for WingetCreate
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Download WingetCreate
+        shell: pwsh
+        run: Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Submit manifest
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
+            throw "Set the WINGET_CREATE_GITHUB_TOKEN repository secret before submitting Winget manifests."
+          }
+
+          .\wingetcreate.exe submit `
+            --prtitle "New version: $env:PACKAGE_ID version $env:VERSION" `
+            --token $env:WINGET_CREATE_GITHUB_TOKEN `
+            --no-open `
+            $env:MANIFEST_ROOT

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ As babies or children smash on the keyboard, colored shapes, letters and numbers
 
 | Platform | Download | Notes |
 |----------|----------|-------|
+| **Windows** | `winget install Hanselman.BabySmash` | Windows Package Manager |
 | **Windows** | [BabySmash-Setup.exe](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-Setup.exe) | Installer with auto-updates |
 | **Windows** | [BabySmash-win-x64.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-win-x64.zip) | Portable version |
 | **Debian/Ubuntu** | [.deb package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |

--- a/docs/winget-release.md
+++ b/docs/winget-release.md
@@ -1,0 +1,76 @@
+# Winget release checklist
+
+This repo publishes a signed Windows installer on every `v*` tag. Winget
+publishing adds a generated manifest submission PR to `microsoft/winget-pkgs`.
+
+## Package identity
+
+- PackageIdentifier: `Hanselman.BabySmash`
+- PackageName: `BabySmash!`
+- Moniker: `babysmash`
+- Publisher: `Scott Hanselman`
+- Installer asset: `BabySmash-Setup.exe`
+
+There is an older community package named `SillyKoalaHugs.BabySmash`; this
+workflow intentionally uses the Hanselman publisher namespace to match
+`Hanselman.WingetTUI`.
+
+## Required secret
+
+The automated workflow uses a repository secret named:
+
+```text
+WINGET_CREATE_GITHUB_TOKEN
+```
+
+Use a token that is accepted by the `microsoft/winget-pkgs` organization policy.
+Classic PATs with a lifetime longer than 90 days are rejected by Microsoft Open
+Source policy.
+
+## Release asset requirements
+
+The Build BabySmash workflow must upload this Windows release asset:
+
+```text
+BabySmash-Setup.exe
+```
+
+The Winget Submit workflow downloads that installer from the release, calculates
+its SHA256, generates a manifest under:
+
+```text
+manifests\h\Hanselman\BabySmash\<version>
+```
+
+and submits it with `wingetcreate`.
+
+## Normal release flow
+
+1. Cut and publish the GitHub release as usual by pushing a `v*` tag.
+2. Confirm the release has the signed `BabySmash-Setup.exe` asset.
+3. Run the **Winget Submit** workflow with the release tag, for example:
+
+```powershell
+gh workflow run winget-submit.yml --repo shanselman/babysmash --ref main -f tag=v4.1.0
+```
+
+4. Watch the workflow:
+
+```powershell
+gh run list --repo shanselman/babysmash --workflow "Winget Submit" --limit 5
+```
+
+5. Track the resulting `microsoft/winget-pkgs` PR until it is merged.
+
+## Manual fallback
+
+If `wingetcreate submit` is blocked by token policy, generate the manifest from
+the same release asset URL and open a PR from a fork of `microsoft/winget-pkgs`.
+Validate before opening the PR:
+
+```powershell
+winget validate --manifest <manifest-folder>
+```
+
+Use manifest schema `1.10.0` for now because it validates cleanly on current
+GitHub-hosted Windows runners and matches the `winget-tui` workflow pattern.


### PR DESCRIPTION
Adds a generated WinGet manifest submission workflow matching the winget-tui release pattern, documents the release process, and advertises the Hanselman.BabySmash package ID in the README.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>