### PR TITLE
Add macOS support via Avalonia

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,114 @@ jobs:
         name: BabySmash-Linux
         path: artifacts/*
 
+
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        rid: [osx-arm64, osx-x64]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v4.5.0
+      with:
+        versionSpec: '6.4.x'
+
+    - name: GitVersion
+      uses: gittools/actions/gitversion/execute@v4.5.0
+      id: gitversion
+
+    - name: Set version environment variables
+      run: |
+        VERSION="${{ steps.gitversion.outputs.semVer }}"
+        FULLVERSION="${{ steps.gitversion.outputs.fullSemVer }}"
+        ASSEMBLY_VERSION="${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.patch }}.0"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "FULLVERSION=$FULLVERSION" >> $GITHUB_ENV
+        echo "ASSEMBLY_VERSION=$ASSEMBLY_VERSION" >> $GITHUB_ENV
+        echo "Using version: $VERSION"
+
+    - name: Restore dependencies
+      run: dotnet restore BabySmash.Linux/BabySmash.Linux.csproj
+
+    - name: Publish macOS ${{ matrix.rid }}
+      run: |
+        dotnet publish BabySmash.Linux/BabySmash.Linux.csproj \
+          -c Release \
+          -r ${{ matrix.rid }} \
+          -p:DebugType=None \
+          -p:DebugSymbols=false \
+          -p:PublishSingleFile=true \
+          -p:Version=$VERSION \
+          -p:AssemblyVersion=$ASSEMBLY_VERSION \
+          -p:FileVersion=$ASSEMBLY_VERSION \
+          -p:AssemblyInformationalVersion=$FULLVERSION \
+          --self-contained
+
+    - name: Create macOS app bundle
+      run: |
+        set -euo pipefail
+        RID="${{ matrix.rid }}"
+        PUBLISH_DIR="BabySmash.Linux/bin/Release/net10.0/$RID/publish"
+        APP_DIR="artifacts/BabySmash.app"
+        MACOS_DIR="$APP_DIR/Contents/MacOS"
+        RESOURCES_DIR="$APP_DIR/Contents/Resources"
+
+        mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+        cp -R "$PUBLISH_DIR"/. "$MACOS_DIR"/
+        if [ -f "$MACOS_DIR/BabySmash.Linux" ]; then
+          mv "$MACOS_DIR/BabySmash.Linux" "$MACOS_DIR/BabySmash"
+        fi
+        chmod +x "$MACOS_DIR/BabySmash"
+        cp Shared/Resources/babysmash.png "$RESOURCES_DIR/" || true
+
+        cat > "$APP_DIR/Contents/Info.plist" <<PLIST
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>CFBundleName</key>
+          <string>BabySmash!</string>
+          <key>CFBundleDisplayName</key>
+          <string>BabySmash!</string>
+          <key>CFBundleIdentifier</key>
+          <string>com.hanselman.babysmash</string>
+          <key>CFBundleVersion</key>
+          <string>$VERSION</string>
+          <key>CFBundleShortVersionString</key>
+          <string>$VERSION</string>
+          <key>CFBundleExecutable</key>
+          <string>BabySmash</string>
+          <key>CFBundlePackageType</key>
+          <string>APPL</string>
+          <key>LSMinimumSystemVersion</key>
+          <string>12.0</string>
+          <key>NSHighResolutionCapable</key>
+          <true/>
+        </dict>
+        </plist>
+        PLIST
+
+        codesign --force --deep --sign - "$APP_DIR"
+        (cd artifacts && ditto -c -k --keepParent "BabySmash.app" "BabySmash-$RID.app.zip")
+        rm -rf "$APP_DIR"
+
+    - name: Upload macOS artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: BabySmash-macOS-${{ matrix.rid }}
+        path: artifacts/*.zip
+
   build-windows-check:
     runs-on: windows-latest
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -258,7 +366,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-macos, build-windows]
     if: startsWith(github.ref, 'refs/tags/')
     
     steps:
@@ -272,6 +380,18 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         name: BabySmash-Windows
+        path: artifacts/
+
+    - name: Download macOS ARM64 artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: BabySmash-macOS-osx-arm64
+        path: artifacts/
+
+    - name: Download macOS Intel artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: BabySmash-macOS-osx-x64
         path: artifacts/
         
     - name: Create Release
@@ -290,16 +410,18 @@ jobs:
           |------|-------------|
           | `BabySmash-Setup.exe` | **Windows** - Installer with Start Menu shortcut |
           | `BabySmash-win-x64.zip` | **Windows** - Portable version (also used by auto-updater) |
+          | `BabySmash-osx-arm64.app.zip` | **macOS Apple Silicon** - Minimal app bundle |
+          | `BabySmash-osx-x64.app.zip` | **macOS Intel** - Minimal app bundle |
           | `babysmash_*_amd64.deb` | **Debian/Ubuntu** - Install with `sudo dpkg -i babysmash_*_amd64.deb` |
           | `babysmash-*.x86_64.rpm` | **Fedora/RHEL** - Install with `sudo rpm -i babysmash-*.x86_64.rpm` |
           | `BabySmash-linux-x64.tar.gz` | **Linux** - Manual install, extract and run `./babysmash` |
           
-          **Self-contained** - No .NET installation required.
+          **Self-contained** - No .NET installation required. macOS bundles are ad-hoc signed but not notarized; first launch may require right-click → Open or approval in Privacy & Security.
           
           ### ⌨️ Usage
           - Press keys and watch shapes and letters appear!
-          - `Alt+O` - Options (Linux) / `Ctrl+Shift+Alt+O` - Options (Windows)
-          - `Escape` - Exit (Linux) / `Alt+F4` - Exit (Windows)
+          - `Alt+O` - Options (Linux/macOS) / `Ctrl+Shift+Alt+O` - Options (Windows)
+          - `Escape` - Exit (Linux/macOS) / `Alt+F4` - Exit (Windows)
           
           ### 🐧 Linux Package Installation
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
 
@@ -193,7 +193,7 @@ jobs:
           <key>CFBundlePackageType</key>
           <string>APPL</string>
           <key>LSMinimumSystemVersion</key>
-          <string>12.0</string>
+          <string>14.0</string>
           <key>NSHighResolutionCapable</key>
           <true/>
         </dict>
@@ -366,9 +366,9 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [build-linux, build-macos, build-windows]
+    needs: [build-linux, build-windows]
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
     - name: Download Linux artifacts
       uses: actions/download-artifact@v8
@@ -382,18 +382,6 @@ jobs:
         name: BabySmash-Windows
         path: artifacts/
 
-    - name: Download macOS ARM64 artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: BabySmash-macOS-osx-arm64
-        path: artifacts/
-
-    - name: Download macOS Intel artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: BabySmash-macOS-osx-x64
-        path: artifacts/
-        
     - name: Create Release
       uses: softprops/action-gh-release@v3.0.2
       with:
@@ -410,13 +398,11 @@ jobs:
           |------|-------------|
           | `BabySmash-Setup.exe` | **Windows** - Installer with Start Menu shortcut |
           | `BabySmash-win-x64.zip` | **Windows** - Portable version (also used by auto-updater) |
-          | `BabySmash-osx-arm64.app.zip` | **macOS Apple Silicon** - Minimal app bundle |
-          | `BabySmash-osx-x64.app.zip` | **macOS Intel** - Minimal app bundle |
           | `babysmash_*_amd64.deb` | **Debian/Ubuntu** - Install with `sudo dpkg -i babysmash_*_amd64.deb` |
           | `babysmash-*.x86_64.rpm` | **Fedora/RHEL** - Install with `sudo rpm -i babysmash-*.x86_64.rpm` |
           | `BabySmash-linux-x64.tar.gz` | **Linux** - Manual install, extract and run `./babysmash` |
-          
-          **Self-contained** - No .NET installation required. macOS bundles are ad-hoc signed but not notarized; first launch may require right-click → Open or approval in Privacy & Security.
+
+          **Self-contained** - No .NET installation required.
           
           ### ⌨️ Usage
           - Press keys and watch shapes and letters appear!

--- a/BabySmash.Linux/App.axaml.cs
+++ b/BabySmash.Linux/App.axaml.cs
@@ -27,11 +27,20 @@ public partial class App : Application
         // Configure dependency injection
         var services = new ServiceCollection();
 
-        // Register Linux-specific platform services
-        services.AddSingleton<ITtsService, LinuxTtsService>();
-        services.AddSingleton<IAudioService, LinuxAudioService>();
+        // Register platform services
+        if (PlatformInfo.IsMacOs)
+        {
+            services.AddSingleton<ITtsService, MacOsTtsService>();
+            services.AddSingleton<IAudioService, MacOsAudioService>();
+            services.AddSingleton<ISettingsService, MacOsSettingsService>();
+        }
+        else
+        {
+            services.AddSingleton<ITtsService, LinuxTtsService>();
+            services.AddSingleton<IAudioService, LinuxAudioService>();
+            services.AddSingleton<ISettingsService, LinuxSettingsService>();
+        }
         services.AddSingleton<IKeyboardHookService, LinuxKeyboardHookService>();
-        services.AddSingleton<ISettingsService, LinuxSettingsService>();
 
         // Register core services
         services.AddSingleton<WordFinder>();
@@ -43,19 +52,19 @@ public partial class App : Application
             // Create first window to get screen info
             var firstWindow = new MainWindow();
             desktop.MainWindow = firstWindow;
-            
+
             // Need to show first window briefly to access Screens
             firstWindow.Show();
-            
+
             // Create a window for each screen (multi-monitor support)
             var screens = firstWindow.Screens;
             bool isFirst = true;
-            
+
             // Put primary screen first, then others (fixes issue on some multi-monitor setups)
             var orderedScreens = screens.All
                 .OrderByDescending(s => s.IsPrimary)
                 .ToList();
-            
+
             foreach (var screen in orderedScreens)
             {
                 MainWindow window;
@@ -69,11 +78,11 @@ public partial class App : Application
                     window = new MainWindow();
                     window.Show();
                 }
-                
+
                 window.Position = new PixelPoint(screen.Bounds.X, screen.Bounds.Y);
                 window.Width = screen.Bounds.Width;
                 window.Height = screen.Bounds.Height;
-                
+
                 Windows.Add(window);
             }
         }

--- a/BabySmash.Linux/App.axaml.cs
+++ b/BabySmash.Linux/App.axaml.cs
@@ -16,6 +16,7 @@ public partial class App : Application
 {
     public static IServiceProvider Services { get; private set; } = null!;
     public static List<MainWindow> Windows { get; } = new();
+    private static ServiceProvider? _serviceProvider;
 
     public override void Initialize()
     {
@@ -45,10 +46,13 @@ public partial class App : Application
         // Register core services
         services.AddSingleton<WordFinder>();
 
-        Services = services.BuildServiceProvider();
+        _serviceProvider = services.BuildServiceProvider();
+        Services = _serviceProvider;
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            desktop.Exit += (_, _) => ShutdownServices();
+
             // Create first window to get screen info
             var firstWindow = new MainWindow();
             desktop.MainWindow = firstWindow;
@@ -88,5 +92,18 @@ public partial class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    private static void ShutdownServices()
+    {
+        if (_serviceProvider == null)
+        {
+            return;
+        }
+
+        Services.GetRequiredService<IAudioService>().StopAll();
+        Services.GetRequiredService<ITtsService>().CancelSpeech();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
     }
 }

--- a/BabySmash.Linux/App.axaml.cs
+++ b/BabySmash.Linux/App.axaml.cs
@@ -81,12 +81,24 @@ public partial class App : Application
                 else
                 {
                     window = new MainWindow();
-                    window.Show();
                 }
 
                 window.Position = new PixelPoint(screen.Bounds.X, screen.Bounds.Y);
-                window.Width = screen.Bounds.Width;
-                window.Height = screen.Bounds.Height;
+                if (PlatformInfo.IsMacOs)
+                {
+                    window.Width = screen.Bounds.Width / screen.Scaling;
+                    window.Height = screen.Bounds.Height / screen.Scaling;
+                }
+                else
+                {
+                    window.Width = screen.Bounds.Width;
+                    window.Height = screen.Bounds.Height;
+                }
+
+                if (window != firstWindow)
+                {
+                    window.Show();
+                }
 
                 Windows.Add(window);
             }

--- a/BabySmash.Linux/BabySmash.Linux.csproj
+++ b/BabySmash.Linux/BabySmash.Linux.csproj
@@ -5,22 +5,22 @@
     <Nullable>disable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    
-    <!-- Linux-specific settings -->
-    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+
+    <!-- Avalonia desktop publish settings -->
+    <RuntimeIdentifiers>linux-x64;osx-arm64;osx-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-    
+
     <!-- Assembly Information -->
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <FileVersion>5.0.0.0</FileVersion>
     <Version>5.0.0</Version>
     <Authors>Scott Hanselman</Authors>
     <Company>Scott Hanselman</Company>
-    <Product>BabySmash! for Linux</Product>
-    <Description>A game for babies who like to bang on the keyboard - Linux version</Description>
-    
+    <Product>BabySmash!</Product>
+    <Description>A game for babies who like to bang on the keyboard - Avalonia desktop version</Description>
+
     <!-- Suppress nullable warnings when disabled -->
     <NoWarn>$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>

--- a/BabySmash.Linux/MainWindow.axaml
+++ b/BabySmash.Linux/MainWindow.axaml
@@ -1,27 +1,27 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="BabySmash.Linux.MainWindow"
-        Title="BabySmash! for Linux"
+        Title="BabySmash!"
         Background="WhiteSmoke"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
         SystemDecorations="None"
         Topmost="True">
-    
+
     <Grid>
         <!-- Main canvas for figures -->
         <Canvas Name="figuresCanvas" Background="Transparent"/>
-        
+
         <!-- Mouse drag canvas (for mouse drawing mode) -->
         <Canvas Name="mouseDragCanvas" Background="Transparent"/>
-        
+
         <!-- Mouse cursor canvas -->
         <Canvas Name="mouseCursorCanvas" Background="Transparent"/>
-        
+
         <!-- Info label (shown on first window only) -->
         <StackPanel Name="infoLabel" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="15" IsVisible="True">
             <TextBlock FontSize="24" FontWeight="Bold" Foreground="#333333">
-                BabySmash! for Linux
+                BabySmash!
             </TextBlock>
             <TextBlock FontSize="14" Margin="0,8,0,0" Foreground="#666666">
                 Press any key to start!

--- a/BabySmash.Linux/MainWindow.axaml
+++ b/BabySmash.Linux/MainWindow.axaml
@@ -4,7 +4,7 @@
         Title="BabySmash!"
         Background="WhiteSmoke"
         WindowState="Maximized"
-        WindowStartupLocation="CenterScreen"
+        WindowStartupLocation="Manual"
         WindowDecorations="None"
         Topmost="True">
     

--- a/BabySmash.Linux/MainWindow.axaml.cs
+++ b/BabySmash.Linux/MainWindow.axaml.cs
@@ -11,6 +11,7 @@ using BabySmash.Linux.Core.Interfaces;
 using BabySmash.Linux.Core.Models;
 using BabySmash.Linux.Core.Services;
 using BabySmash.Linux.Shapes;
+using BabySmash.Linux.Platform;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BabySmash.Linux;
@@ -33,20 +34,20 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-        
+
         // Get services from DI
         _ttsService = App.Services.GetRequiredService<ITtsService>();
         _audioService = App.Services.GetRequiredService<IAudioService>();
         _settingsService = App.Services.GetRequiredService<ISettingsService>();
         _wordFinder = App.Services.GetRequiredService<WordFinder>();
-        
+
         // Hook up input events
         KeyDown += OnKeyDown;
         PointerPressed += OnPointerPressed;
         PointerReleased += OnPointerReleased;
         PointerMoved += OnPointerMoved;
         PointerWheelChanged += OnPointerWheelChanged;
-        
+
         // Focus management timer
         _focusTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _focusTimer.Tick += (s, e) =>
@@ -57,33 +58,48 @@ public partial class MainWindow : Window
                 Focus();
             }
         };
-        
+
         Loaded += OnLoaded;
     }
 
     private void OnLoaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
+        ApplyPlatformWindowMode();
         Focus();
-        _focusTimer.Start();
-        
+        if (!PlatformInfo.IsMacOs)
+        {
+            _focusTimer.Start();
+        }
+
         // Play startup sound
         _audioService.PlaySound("EditedJackPlaysBabySmash.wav");
-        
+
         // Setup custom cursor
         SetupCustomCursor();
+    }
+
+    private void ApplyPlatformWindowMode()
+    {
+        Title = $"BabySmash! for {PlatformInfo.DisplayName}";
+
+        if (PlatformInfo.IsMacOs)
+        {
+            WindowState = WindowState.FullScreen;
+            Topmost = false;
+        }
     }
 
     private void SetupCustomCursor()
     {
         // Hide system cursor
         Cursor = new Cursor(StandardCursorType.None);
-        
+
         // Create custom cursor (arrow)
         _customCursor = new FunCursor1();
         _customCursor.ZIndex = 10000; // Always on top
         _customCursor.IsHitTestVisible = false;
         _customCursor.RenderTransform = new ScaleTransform(0.5, 0.5); // Make it smaller
-        
+
         var canvas = this.FindControl<Canvas>("mainCanvas");
         canvas?.Children.Add(_customCursor);
     }
@@ -96,7 +112,7 @@ public partial class MainWindow : Window
         {
             infoLabel.IsVisible = false;
         }
-        
+
         // Exit on Escape
         if (e.Key == Key.Escape)
         {
@@ -119,16 +135,16 @@ public partial class MainWindow : Window
         if (displayChar.HasValue)
         {
             char c = displayChar.Value;
-            
+
             // Apply ForceUppercase setting
             var forceUpper = _settingsService.Get(SettingsKeys.ForceUppercase, SettingsDefaults.ForceUppercase);
             if (forceUpper && char.IsLetter(c))
             {
                 c = char.ToUpper(c);
             }
-            
+
             var template = BabySmashUtils.GenerateFigureTemplate(c);
-            
+
             // Add figure to ALL windows first (matching Windows behavior)
             foreach (var window in App.Windows)
             {
@@ -138,7 +154,7 @@ public partial class MainWindow : Window
             // Find the last word typed using first window's queue
             var firstWindow = App.Windows.FirstOrDefault();
             string? lastWord = firstWindow != null ? _wordFinder.LastWord(firstWindow._figuresList) : null;
-            
+
             if (lastWord != null)
             {
                 // Animate on ALL windows
@@ -201,19 +217,19 @@ public partial class MainWindow : Window
         {
             return (char)('A' + (key - Key.A));
         }
-        
+
         // Numbers 0-9 (top row)
         if (key >= Key.D0 && key <= Key.D9)
         {
             return (char)('0' + (key - Key.D0));
         }
-        
+
         // Numpad 0-9
         if (key >= Key.NumPad0 && key <= Key.NumPad9)
         {
             return (char)('0' + (key - Key.NumPad0));
         }
-        
+
         // Any other key generates a random shape (matching Windows behavior)
         return '*';
     }
@@ -221,24 +237,24 @@ public partial class MainWindow : Window
     public void AddFigure(FigureTemplate template)
     {
         var figure = FigureGenerator.CreateFigure(template);
-        
+
         // Set face visibility based on settings
         var showFaces = _settingsService.Get(SettingsKeys.FacesOnShapes, SettingsDefaults.FacesOnShapes);
         FigureGenerator.SetFaceVisibility(figure, showFaces);
-        
+
         // Calculate size and position
         double figureWidth = figure.Width > 0 ? figure.Width : 200;
         double figureHeight = figure.Height > 0 ? figure.Height : 200;
-        
+
         var x = BabySmashUtils.RandomBetweenTwoNumbers(0, (int)Math.Max(1, Bounds.Width - figureWidth));
         var y = BabySmashUtils.RandomBetweenTwoNumbers(0, (int)Math.Max(1, Bounds.Height - figureHeight));
-        
+
         Canvas.SetLeft(figure, x);
         Canvas.SetTop(figure, y);
-        
+
         // Add spawn animation (scale + rotate)
         ApplySpawnAnimation(figure);
-        
+
         figuresCanvas.Children.Add(figure);
         _figuresQueue.Enqueue(figure);
         _figuresList.Add(figure);
@@ -269,32 +285,32 @@ public partial class MainWindow : Window
         var rotateTransform = new RotateTransform(360);
         transformGroup.Children.Add(scaleTransform);
         transformGroup.Children.Add(rotateTransform);
-        
+
         figure.RenderTransform = transformGroup;
         figure.RenderTransformOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative);
-        
+
         // Use random easing type like Windows
         var easingType = BabySmashUtils.RandomBetweenTwoNumbers(0, 4);
-        
+
         var startTime = DateTime.Now;
         var duration = TimeSpan.FromSeconds(1.0); // 1 second like Windows
-        
+
         var timer = CreateAnimationTimer(TimeSpan.FromMilliseconds(16));
         timer.Tick += (s, e) =>
         {
             var elapsed = DateTime.Now - startTime;
             var progress = Math.Min(1.0, elapsed.TotalMilliseconds / duration.TotalMilliseconds);
-            
+
             // Apply easing
             var easedProgress = ApplyEasing(progress, easingType);
-            
+
             // Scale: 0 → 1
             scaleTransform.ScaleX = easedProgress;
             scaleTransform.ScaleY = easedProgress;
-            
+
             // Rotate: 360 → 0
             rotateTransform.Angle = 360 * (1 - easedProgress);
-            
+
             if (progress >= 1.0)
             {
                 RemoveAnimationTimer(timer);
@@ -367,7 +383,7 @@ public partial class MainWindow : Window
         // Find the letter figures that make up this word (the last N figures that are CoolLetters)
         var letterFigures = new List<CoolLetter>();
         var figureList = _figuresList.ToArray();
-        
+
         for (int i = figureList.Length - 1; i >= 0 && letterFigures.Count < word.Length; i--)
         {
             if (figureList[i] is CoolLetter letter)
@@ -379,58 +395,58 @@ public partial class MainWindow : Window
                 break; // Stop if we hit a non-letter
             }
         }
-        
+
         if (letterFigures.Count < word.Length)
             return; // Not enough letters
-        
+
         // Calculate word center (average position of letters)
         double centerX = letterFigures.Average(l => Canvas.GetLeft(l) + l.Width / 2);
         double centerY = letterFigures.Average(l => Canvas.GetTop(l) + l.Height / 2);
-        
+
         // Calculate total word width
         double totalWidth = letterFigures.Sum(l => l.Width);
         double leftEdge = centerX - totalWidth / 2;
-        
+
         // Animate each letter to its position in the word
         var duration = TimeSpan.FromMilliseconds(1200);
         double currentX = leftEdge;
-        
+
         foreach (var letter in letterFigures)
         {
             double startX = Canvas.GetLeft(letter);
             double startY = Canvas.GetTop(letter);
             double targetX = currentX;
             double targetY = centerY - letter.Height / 2;
-            
+
             var startTime = DateTime.Now;
             var timer = CreateAnimationTimer(TimeSpan.FromMilliseconds(16));
-            
+
             var capturedLetter = letter;
             var capturedTargetX = targetX;
             var capturedTargetY = targetY;
             var capturedStartX = startX;
             var capturedStartY = startY;
             var capturedTimer = timer;
-            
+
             timer.Tick += (s, e) =>
             {
                 var elapsed = DateTime.Now - startTime;
                 var progress = Math.Min(1.0, elapsed.TotalMilliseconds / duration.TotalMilliseconds);
                 var easedProgress = QuadEaseOut(progress);
-                
+
                 double newX = capturedStartX + (capturedTargetX - capturedStartX) * easedProgress;
                 double newY = capturedStartY + (capturedTargetY - capturedStartY) * easedProgress;
-                
+
                 Canvas.SetLeft(capturedLetter, newX);
                 Canvas.SetTop(capturedLetter, newY);
-                
+
                 if (progress >= 1.0)
                 {
                     RemoveAnimationTimer(capturedTimer);
                 }
             };
             timer.Start();
-            
+
             currentX += letter.Width;
         }
     }
@@ -440,15 +456,15 @@ public partial class MainWindow : Window
         // Simple fade using timer
         var startTime = DateTime.Now;
         var duration = TimeSpan.FromSeconds(fadeAfterSeconds);
-        
+
         var timer = CreateAnimationTimer(TimeSpan.FromMilliseconds(50));
         timer.Tick += (s, e) =>
         {
             var elapsed = DateTime.Now - startTime;
             var progress = Math.Min(1.0, elapsed.TotalMilliseconds / duration.TotalMilliseconds);
-            
+
             figure.Opacity = 1.0 - progress;
-            
+
             if (progress >= 1.0)
             {
                 RemoveAnimationTimer(timer);
@@ -461,7 +477,7 @@ public partial class MainWindow : Window
     private void PlaySound(FigureTemplate template)
     {
         var soundMode = _settingsService.Get(SettingsKeys.Sounds, SettingsDefaults.Sounds);
-        
+
         if (soundMode == "Laughter")
         {
             _audioService.PlaySound(BabySmashUtils.GetRandomSoundFile());
@@ -483,11 +499,11 @@ public partial class MainWindow : Window
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         var mouseDraw = _settingsService.Get(SettingsKeys.MouseDraw, SettingsDefaults.MouseDraw);
-        
+
         // Check if we clicked on an existing figure
         var point = e.GetPosition(figuresCanvas);
         var clickedFigure = FindFigureAtPoint(point);
-        
+
         if (clickedFigure != null && clickedFigure.Opacity > 0.1)
         {
             // Apply random animation effect to the clicked figure
@@ -496,13 +512,13 @@ public partial class MainWindow : Window
             _isDrawing = true; // Prevent mouse draw on this click
             return;
         }
-        
+
         if (_isDrawing || mouseDraw) return;
 
         MouseDraw(point);
         _isDrawing = true;
         e.Pointer.Capture(this);
-        
+
         _audioService.PlaySound("smallbumblebee.wav");
     }
 
@@ -515,7 +531,7 @@ public partial class MainWindow : Window
             var left = Canvas.GetLeft(figure);
             var top = Canvas.GetTop(figure);
             var bounds = new Rect(left, top, figure.Bounds.Width, figure.Bounds.Height);
-            
+
             if (bounds.Contains(point))
             {
                 return figure;
@@ -527,7 +543,7 @@ public partial class MainWindow : Window
     private void ApplyRandomClickAnimation(Control figure)
     {
         var animationType = BabySmashUtils.RandomBetweenTwoNumbers(0, 3);
-        
+
         switch (animationType)
         {
             case 0:
@@ -550,7 +566,7 @@ public partial class MainWindow : Window
         figure.RenderTransformOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative);
         var rotateTransform = new RotateTransform(0);
         figure.RenderTransform = rotateTransform;
-        
+
         var keyframes = new[] { 0.0, 10.0, 0.0, -10.0, 0.0, 5.0, 0.0, -5.0, 0.0 };
         AnimateWithKeyframes(rotateTransform, keyframes, angle => rotateTransform.Angle = angle, TimeSpan.FromSeconds(0.5));
     }
@@ -560,7 +576,7 @@ public partial class MainWindow : Window
         figure.RenderTransformOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative);
         var scaleTransform = new ScaleTransform(1, 1);
         figure.RenderTransform = scaleTransform;
-        
+
         var keyframes = new[] { 1.0, 1.1, 1.0, 0.9, 1.0, 1.05, 1.0, 0.95, 1.0 };
         AnimateWithKeyframes(scaleTransform, keyframes, scale =>
         {
@@ -574,7 +590,7 @@ public partial class MainWindow : Window
         figure.RenderTransformOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative);
         var rotateTransform = new RotateTransform(0);
         figure.RenderTransform = rotateTransform;
-        
+
         var keyframes = new[] { 0.0, -5.0, 0.0, 90.0, 180.0, 270.0, 360.0, 365.0, 360.0 };
         AnimateWithKeyframes(rotateTransform, keyframes, angle => rotateTransform.Angle = angle, TimeSpan.FromSeconds(1.0));
     }
@@ -584,7 +600,7 @@ public partial class MainWindow : Window
         figure.RenderTransformOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative);
         var scaleTransform = new ScaleTransform(1, 1);
         figure.RenderTransform = scaleTransform;
-        
+
         var keyframes = new[] { 1.0, 0.0, 1.0 };
         AnimateWithKeyframes(scaleTransform, keyframes, scale => scaleTransform.ScaleY = scale, TimeSpan.FromSeconds(0.3));
     }
@@ -593,21 +609,21 @@ public partial class MainWindow : Window
     {
         var startTime = DateTime.Now;
         var timer = CreateAnimationTimer(TimeSpan.FromMilliseconds(16));
-        
+
         timer.Tick += (s, e) =>
         {
             var elapsed = DateTime.Now - startTime;
             var progress = Math.Min(1.0, elapsed.TotalMilliseconds / duration.TotalMilliseconds);
-            
+
             // Interpolate between keyframes
             var frameIndex = progress * (keyframes.Length - 1);
             var lowerIndex = (int)Math.Floor(frameIndex);
             var upperIndex = Math.Min(lowerIndex + 1, keyframes.Length - 1);
             var frameFraction = frameIndex - lowerIndex;
-            
+
             var value = keyframes[lowerIndex] + (keyframes[upperIndex] - keyframes[lowerIndex]) * frameFraction;
             setValue(value);
-            
+
             if (progress >= 1.0)
             {
                 RemoveAnimationTimer(timer);
@@ -626,18 +642,18 @@ public partial class MainWindow : Window
     private void OnPointerMoved(object? sender, PointerEventArgs e)
     {
         if (_isOptionsDialogShown) return;
-        
+
         var point = e.GetPosition(this);
-        
+
         // Update custom cursor position
         if (_customCursor != null)
         {
             Canvas.SetLeft(_customCursor, point.X - 5);
             Canvas.SetTop(_customCursor, point.Y - 5);
         }
-        
+
         var mouseDraw = _settingsService.Get(SettingsKeys.MouseDraw, SettingsDefaults.MouseDraw);
-        
+
         if (_isDrawing || mouseDraw)
         {
             MouseDraw(point);
@@ -689,7 +705,7 @@ public partial class MainWindow : Window
     {
         var lighter = color.LightenOrDarken(50);
         var darker = color.LightenOrDarken(-50);
-        
+
         return new RadialGradientBrush
         {
             GradientOrigin = new RelativePoint(0.75, 0.25, RelativeUnit.Relative),
@@ -706,19 +722,22 @@ public partial class MainWindow : Window
     {
         _isOptionsDialogShown = true;
         Topmost = false;
-        
+
         try
         {
             var optionsWindow = new OptionsWindow();
-            optionsWindow.Topmost = true;
+            optionsWindow.Topmost = !PlatformInfo.IsMacOs;
             await optionsWindow.ShowDialog(this);
         }
         finally
         {
             _isOptionsDialogShown = false;
-            Topmost = true;
-            Activate();
-            Focus();
+            Topmost = !PlatformInfo.IsMacOs;
+            if (!PlatformInfo.IsMacOs)
+            {
+                Activate();
+                Focus();
+            }
         }
     }
 }

--- a/BabySmash.Linux/MainWindow.axaml.cs
+++ b/BabySmash.Linux/MainWindow.axaml.cs
@@ -175,6 +175,9 @@ public partial class MainWindow : Window
 
     private void CloseAllWindows()
     {
+        _audioService.StopAll();
+        _ttsService.CancelSpeech();
+
         foreach (var window in App.Windows)
         {
             if (window != this)

--- a/BabySmash.Linux/MainWindow.axaml.cs
+++ b/BabySmash.Linux/MainWindow.axaml.cs
@@ -63,11 +63,13 @@ public partial class MainWindow : Window
 
         Loaded += OnLoaded;
         Closed += OnClosed;
+
+        ApplyPlatformWindowState();
     }
 
     private void OnLoaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        ApplyPlatformWindowMode();
+        ApplyPlatformWindowTitle();
         Focus();
         if (!PlatformInfo.IsMacOs)
         {
@@ -88,15 +90,18 @@ public partial class MainWindow : Window
         _keyboardHookService.RestoreSystemScreenshotShortcut();
     }
 
-    private void ApplyPlatformWindowMode()
+    private void ApplyPlatformWindowState()
     {
-        Title = $"BabySmash! for {PlatformInfo.DisplayName}";
-
         if (PlatformInfo.IsMacOs)
         {
-            WindowState = WindowState.FullScreen;
+            WindowState = WindowState.Normal;
             Topmost = false;
         }
+    }
+
+    private void ApplyPlatformWindowTitle()
+    {
+        Title = $"BabySmash! for {PlatformInfo.DisplayName}";
     }
 
     private void SetupCustomCursor()

--- a/BabySmash.Linux/OptionsWindow.axaml
+++ b/BabySmash.Linux/OptionsWindow.axaml
@@ -5,6 +5,7 @@
         Width="500" Height="400"
         WindowStartupLocation="CenterScreen"
         CanResize="False"
+        RequestedThemeVariant="Light"
         Background="#F5F5F5">
     
     <Grid Margin="20">

--- a/BabySmash.Linux/OptionsWindow.axaml
+++ b/BabySmash.Linux/OptionsWindow.axaml
@@ -47,7 +47,7 @@
                 <NumericUpDown Name="ClearAfterNumeric" 
                                Minimum="5" Maximum="100" 
                                Value="30" 
-                               Width="100"/>
+                               MinWidth="120"/>
                 <TextBlock Text="shapes" VerticalAlignment="Center"/>
             </StackPanel>
             

--- a/BabySmash.Linux/Platform/MacOsAudioService.cs
+++ b/BabySmash.Linux/Platform/MacOsAudioService.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using BabySmash.Linux.Core.Interfaces;
+
+namespace BabySmash.Linux.Platform;
+
+public class MacOsAudioService : IAudioService, IDisposable
+{
+    private const string AfplayPath = "/usr/bin/afplay";
+    private readonly string _tempDir;
+    private readonly List<Process> _runningProcesses = new();
+    private readonly object _processLock = new();
+    private bool _warningShown;
+    private readonly bool _audioAvailable;
+
+    public MacOsAudioService()
+    {
+        _tempDir = Path.Combine(GetHomeDirectory(), "Library", "Caches", "BabySmash", "Sounds");
+        Directory.CreateDirectory(_tempDir);
+        _audioAvailable = File.Exists(AfplayPath);
+    }
+
+    public void PlaySound(string resourceName)
+    {
+        if (!_audioAvailable)
+        {
+            ShowAudioWarningOnce();
+            return;
+        }
+
+        try
+        {
+            var soundFile = ExtractSoundResource(resourceName);
+            if (soundFile == null) return;
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = AfplayPath,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardError = true
+                },
+                EnableRaisingEvents = true
+            };
+            process.StartInfo.ArgumentList.Add(soundFile);
+
+            process.Exited += (s, e) =>
+            {
+                lock (_processLock)
+                {
+                    _runningProcesses.Remove(process);
+                }
+                process.Dispose();
+            };
+
+            lock (_processLock)
+            {
+                _runningProcesses.Add(process);
+            }
+
+            if (!process.Start())
+            {
+                lock (_processLock)
+                {
+                    _runningProcesses.Remove(process);
+                }
+                process.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Audio error: {ex.Message}");
+        }
+    }
+
+    private string? ExtractSoundResource(string resourceName)
+    {
+        var outputPath = Path.Combine(_tempDir, resourceName);
+        if (File.Exists(outputPath))
+        {
+            return outputPath;
+        }
+
+        var assembly = typeof(BabySmash.Linux.Core.Services.WordFinder).Assembly;
+        var resourceFullName = $"BabySmash.Linux.Core.Resources.Sounds.{resourceName}";
+
+        using var stream = assembly.GetManifestResourceStream(resourceFullName);
+        if (stream == null)
+        {
+            var names = assembly.GetManifestResourceNames();
+            var match = Array.Find(names, n => n.EndsWith(resourceName, StringComparison.OrdinalIgnoreCase));
+            if (match == null) return null;
+
+            using var matchStream = assembly.GetManifestResourceStream(match);
+            if (matchStream == null) return null;
+
+            using var matchFileStream = File.Create(outputPath);
+            matchStream.CopyTo(matchFileStream);
+            return outputPath;
+        }
+
+        using var fileStream = File.Create(outputPath);
+        stream.CopyTo(fileStream);
+        return outputPath;
+    }
+
+    public void StopAll()
+    {
+        lock (_processLock)
+        {
+            foreach (var process in _runningProcesses.ToArray())
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    process.Dispose();
+                }
+                catch
+                {
+                    // Ignore shutdown races.
+                }
+            }
+            _runningProcesses.Clear();
+        }
+    }
+
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors.
+        }
+    }
+
+    public void Dispose()
+    {
+        StopAll();
+        Cleanup();
+    }
+
+    private void ShowAudioWarningOnce()
+    {
+        if (_warningShown) return;
+
+        Console.WriteLine();
+        Console.WriteLine("╔══════════════════════════════════════════════════════════════╗");
+        Console.WriteLine("║  WARNING: macOS audio playback is not available              ║");
+        Console.WriteLine("║                                                              ║");
+        Console.WriteLine("║  BabySmash expects /usr/bin/afplay for sound playback.       ║");
+        Console.WriteLine("╚══════════════════════════════════════════════════════════════╝");
+        Console.WriteLine();
+        _warningShown = true;
+    }
+
+    private static string GetHomeDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return string.IsNullOrWhiteSpace(home) ? Environment.GetEnvironmentVariable("HOME") ?? "." : home;
+    }
+}

--- a/BabySmash.Linux/Platform/MacOsAudioService.cs
+++ b/BabySmash.Linux/Platform/MacOsAudioService.cs
@@ -9,6 +9,7 @@ namespace BabySmash.Linux.Platform;
 public class MacOsAudioService : IAudioService, IDisposable
 {
     private const string AfplayPath = "/usr/bin/afplay";
+    private const int MaxConcurrentSounds = 8;
     private readonly string _tempDir;
     private readonly List<Process> _runningProcesses = new();
     private readonly object _processLock = new();
@@ -57,23 +58,67 @@ public class MacOsAudioService : IAudioService, IDisposable
                 process.Dispose();
             };
 
-            lock (_processLock)
+            if (!TryStartSoundProcess(process))
             {
-                _runningProcesses.Add(process);
-            }
-
-            if (!process.Start())
-            {
-                lock (_processLock)
-                {
-                    _runningProcesses.Remove(process);
-                }
                 process.Dispose();
             }
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Audio error: {ex.Message}");
+        }
+    }
+
+    private bool TryStartSoundProcess(Process process)
+    {
+        lock (_processLock)
+        {
+            RemoveExitedProcesses();
+            if (_runningProcesses.Count >= MaxConcurrentSounds)
+            {
+                return false;
+            }
+
+            _runningProcesses.Add(process);
+
+            try
+            {
+                if (process.Start())
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                _runningProcesses.Remove(process);
+                process.Dispose();
+                throw;
+            }
+
+            _runningProcesses.Remove(process);
+            return false;
+        }
+    }
+
+    private void RemoveExitedProcesses()
+    {
+        for (var i = _runningProcesses.Count - 1; i >= 0; i--)
+        {
+            var process = _runningProcesses[i];
+            try
+            {
+                if (!process.HasExited)
+                {
+                    continue;
+                }
+            }
+            catch
+            {
+                // Treat inaccessible process handles as no longer usable.
+            }
+
+            _runningProcesses.RemoveAt(i);
+            process.Dispose();
         }
     }
 

--- a/BabySmash.Linux/Platform/MacOsAudioService.cs
+++ b/BabySmash.Linux/Platform/MacOsAudioService.cs
@@ -63,9 +63,9 @@ public class MacOsAudioService : IAudioService, IDisposable
                 process.Dispose();
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            Console.WriteLine($"Audio error: {ex.Message}");
+            Console.WriteLine("Audio playback failed.");
         }
     }
 

--- a/BabySmash.Linux/Platform/MacOsAudioService.cs
+++ b/BabySmash.Linux/Platform/MacOsAudioService.cs
@@ -42,8 +42,7 @@ public class MacOsAudioService : IAudioService, IDisposable
                 {
                     FileName = AfplayPath,
                     CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardError = true
+                    UseShellExecute = false
                 },
                 EnableRaisingEvents = true
             };

--- a/BabySmash.Linux/Platform/MacOsSettingsService.cs
+++ b/BabySmash.Linux/Platform/MacOsSettingsService.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using BabySmash.Linux.Core.Interfaces;
+
+namespace BabySmash.Linux.Platform;
+
+public class MacOsSettingsService : ISettingsService
+{
+    private readonly string _settingsPath;
+    private Dictionary<string, object> _settings = new();
+
+    public MacOsSettingsService()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+        {
+            home = Environment.GetEnvironmentVariable("HOME") ?? ".";
+        }
+
+        var configDir = Path.Combine(home, "Library", "Application Support", "BabySmash");
+        Directory.CreateDirectory(configDir);
+        _settingsPath = Path.Combine(configDir, "settings.json");
+        Load();
+    }
+
+    public T Get<T>(string key, T defaultValue = default!)
+    {
+        if (_settings.TryGetValue(key, out var value))
+        {
+            if (value is JsonElement jsonElement)
+            {
+                return jsonElement.Deserialize<T>() ?? defaultValue;
+            }
+            if (value is T typedValue)
+            {
+                return typedValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    public void Set<T>(string key, T value)
+    {
+        _settings[key] = value!;
+    }
+
+    public void Save()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_settingsPath, json);
+        }
+        catch
+        {
+            // Silently fail to match Linux settings behavior.
+        }
+    }
+
+    public void Load()
+    {
+        try
+        {
+            if (File.Exists(_settingsPath))
+            {
+                var json = File.ReadAllText(_settingsPath);
+                _settings = JsonSerializer.Deserialize<Dictionary<string, object>>(json) ?? new();
+            }
+        }
+        catch
+        {
+            _settings = new();
+        }
+    }
+}

--- a/BabySmash.Linux/Platform/MacOsTtsService.cs
+++ b/BabySmash.Linux/Platform/MacOsTtsService.cs
@@ -65,23 +65,39 @@ public class MacOsTtsService : ITtsService, IDisposable
                 process.Dispose();
             };
 
-            lock (_processLock)
+            if (!TryStartSpeechProcess(process))
             {
-                _runningProcesses.Add(process);
-            }
-
-            if (!process.Start())
-            {
-                lock (_processLock)
-                {
-                    _runningProcesses.Remove(process);
-                }
                 process.Dispose();
             }
         }
         catch (Exception ex)
         {
             Console.WriteLine($"TTS error: {ex.Message}");
+        }
+    }
+
+    private bool TryStartSpeechProcess(Process process)
+    {
+        lock (_processLock)
+        {
+            _runningProcesses.Add(process);
+
+            try
+            {
+                if (process.Start())
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                _runningProcesses.Remove(process);
+                process.Dispose();
+                throw;
+            }
+
+            _runningProcesses.Remove(process);
+            return false;
         }
     }
 

--- a/BabySmash.Linux/Platform/MacOsTtsService.cs
+++ b/BabySmash.Linux/Platform/MacOsTtsService.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using BabySmash.Linux.Core.Interfaces;
+
+namespace BabySmash.Linux.Platform;
+
+public class MacOsTtsService : ITtsService, IDisposable
+{
+    private const string SayPath = "/usr/bin/say";
+    private readonly List<Process> _runningProcesses = new();
+    private readonly object _processLock = new();
+    private readonly List<SayVoice> _voices;
+    private readonly bool _sayAvailable;
+    private bool _warningShown;
+    private string? _currentVoice;
+
+    public MacOsTtsService()
+    {
+        _sayAvailable = File.Exists(SayPath);
+        _voices = _sayAvailable ? ProbeVoices() : new List<SayVoice>();
+    }
+
+    public void Speak(string text)
+    {
+        if (!_sayAvailable)
+        {
+            ShowTtsWarningOnce();
+            return;
+        }
+
+        try
+        {
+            CancelSpeech();
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = SayPath,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardError = true
+                },
+                EnableRaisingEvents = true
+            };
+
+            if (!string.IsNullOrWhiteSpace(_currentVoice))
+            {
+                process.StartInfo.ArgumentList.Add("-v");
+                process.StartInfo.ArgumentList.Add(_currentVoice);
+            }
+            process.StartInfo.ArgumentList.Add(text);
+
+            process.Exited += (s, e) =>
+            {
+                lock (_processLock)
+                {
+                    _runningProcesses.Remove(process);
+                }
+                process.Dispose();
+            };
+
+            lock (_processLock)
+            {
+                _runningProcesses.Add(process);
+            }
+
+            if (!process.Start())
+            {
+                lock (_processLock)
+                {
+                    _runningProcesses.Remove(process);
+                }
+                process.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"TTS error: {ex.Message}");
+        }
+    }
+
+    public bool TrySetLanguage(CultureInfo culture)
+    {
+        if (!_sayAvailable)
+        {
+            _currentVoice = null;
+            return false;
+        }
+
+        var normalizedName = NormalizeCulture(culture.Name);
+        var languageName = NormalizeCulture(culture.TwoLetterISOLanguageName);
+
+        var voice = _voices.FirstOrDefault(v => v.NormalizedLocale == normalizedName)
+            ?? _voices.FirstOrDefault(v => v.NormalizedLocale.StartsWith(languageName + "-", StringComparison.OrdinalIgnoreCase))
+            ?? _voices.FirstOrDefault(v => v.NormalizedLocale.Equals(languageName, StringComparison.OrdinalIgnoreCase));
+
+        _currentVoice = voice?.Name;
+        return voice != null || _voices.Count == 0;
+    }
+
+    public void CancelSpeech()
+    {
+        lock (_processLock)
+        {
+            foreach (var process in _runningProcesses.ToArray())
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    process.Dispose();
+                }
+                catch
+                {
+                    // Ignore shutdown races.
+                }
+            }
+            _runningProcesses.Clear();
+        }
+    }
+
+    public void Dispose()
+    {
+        CancelSpeech();
+    }
+
+    private static List<SayVoice> ProbeVoices()
+    {
+        var voices = new List<SayVoice>();
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = SayPath,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                }
+            };
+            process.StartInfo.ArgumentList.Add("-v");
+            process.StartInfo.ArgumentList.Add("?");
+
+            process.Start();
+            if (!process.WaitForExit(2000))
+            {
+                process.Kill(entireProcessTree: true);
+                return voices;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            foreach (var line in output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var match = Regex.Match(line, @"^(?<name>.+?)\s+(?<locale>[a-z]{2}[_-][A-Z]{2}|[a-z]{2})\s+#", RegexOptions.CultureInvariant);
+                if (match.Success)
+                {
+                    voices.Add(new SayVoice(
+                        match.Groups["name"].Value.Trim(),
+                        NormalizeCulture(match.Groups["locale"].Value)));
+                }
+            }
+        }
+        catch
+        {
+            // Voice probing is best-effort; say can still use its default voice.
+        }
+
+        return voices;
+    }
+
+    private void ShowTtsWarningOnce()
+    {
+        if (_warningShown) return;
+
+        Console.WriteLine();
+        Console.WriteLine("╔══════════════════════════════════════════════════════════════╗");
+        Console.WriteLine("║  WARNING: macOS text-to-speech is not available              ║");
+        Console.WriteLine("║                                                              ║");
+        Console.WriteLine("║  BabySmash expects /usr/bin/say for speech support.          ║");
+        Console.WriteLine("╚══════════════════════════════════════════════════════════════╝");
+        Console.WriteLine();
+        _warningShown = true;
+    }
+
+    private static string NormalizeCulture(string culture)
+    {
+        return culture.Replace('_', '-').ToLowerInvariant();
+    }
+
+    private sealed record SayVoice(string Name, string NormalizedLocale);
+}

--- a/BabySmash.Linux/Platform/MacOsTtsService.cs
+++ b/BabySmash.Linux/Platform/MacOsTtsService.cs
@@ -13,6 +13,7 @@ namespace BabySmash.Linux.Platform;
 public class MacOsTtsService : ITtsService, IDisposable
 {
     private const string SayPath = "/usr/bin/say";
+    private const int VoiceProbeTimeoutMilliseconds = 2000;
     private readonly List<Process> _runningProcesses = new();
     private readonly object _processLock = new();
     private readonly List<SayVoice> _voices;
@@ -172,19 +173,23 @@ public class MacOsTtsService : ITtsService, IDisposable
             process.Start();
             var outputTask = process.StandardOutput.ReadToEndAsync();
             var errorTask = process.StandardError.ReadToEndAsync();
+            var probeTasks = new Task[] { outputTask, errorTask };
 
-            if (!process.WaitForExit(2000))
+            if (!process.WaitForExit(VoiceProbeTimeoutMilliseconds))
             {
                 if (!process.HasExited)
                 {
                     process.Kill(entireProcessTree: true);
                 }
-                process.WaitForExit();
-                Task.WaitAll(outputTask, errorTask);
+                process.WaitForExit(VoiceProbeTimeoutMilliseconds);
+                Task.WaitAll(probeTasks, VoiceProbeTimeoutMilliseconds);
                 return voices;
             }
 
-            Task.WaitAll(outputTask, errorTask);
+            if (!Task.WaitAll(probeTasks, VoiceProbeTimeoutMilliseconds))
+            {
+                return voices;
+            }
             var output = outputTask.Result;
             foreach (var line in output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
             {

--- a/BabySmash.Linux/Platform/MacOsTtsService.cs
+++ b/BabySmash.Linux/Platform/MacOsTtsService.cs
@@ -16,7 +16,8 @@ public class MacOsTtsService : ITtsService, IDisposable
     private const int VoiceProbeTimeoutMilliseconds = 2000;
     private readonly List<Process> _runningProcesses = new();
     private readonly object _processLock = new();
-    private readonly List<SayVoice> _voices;
+    private readonly object _voiceLock = new();
+    private List<SayVoice>? _voices;
     private readonly bool _sayAvailable;
     private bool _warningShown;
     private string? _currentVoice;
@@ -24,7 +25,6 @@ public class MacOsTtsService : ITtsService, IDisposable
     public MacOsTtsService()
     {
         _sayAvailable = File.Exists(SayPath);
-        _voices = _sayAvailable ? ProbeVoices() : new List<SayVoice>();
     }
 
     public void Speak(string text)
@@ -45,8 +45,7 @@ public class MacOsTtsService : ITtsService, IDisposable
                 {
                     FileName = SayPath,
                     CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardError = true
+                    UseShellExecute = false
                 },
                 EnableRaisingEvents = true
             };
@@ -111,15 +110,26 @@ public class MacOsTtsService : ITtsService, IDisposable
             return false;
         }
 
+        var voices = EnsureVoices();
+
         var normalizedName = NormalizeCulture(culture.Name);
         var languageName = NormalizeCulture(culture.TwoLetterISOLanguageName);
 
-        var voice = _voices.FirstOrDefault(v => v.NormalizedLocale == normalizedName)
-            ?? _voices.FirstOrDefault(v => v.NormalizedLocale.StartsWith(languageName + "-", StringComparison.OrdinalIgnoreCase))
-            ?? _voices.FirstOrDefault(v => v.NormalizedLocale.Equals(languageName, StringComparison.OrdinalIgnoreCase));
+        var voice = voices.FirstOrDefault(v => v.NormalizedLocale == normalizedName)
+            ?? voices.FirstOrDefault(v => v.NormalizedLocale.StartsWith(languageName + "-", StringComparison.OrdinalIgnoreCase))
+            ?? voices.FirstOrDefault(v => v.NormalizedLocale.Equals(languageName, StringComparison.OrdinalIgnoreCase));
 
         _currentVoice = voice?.Name;
-        return voice != null || _voices.Count == 0;
+        return voice != null || voices.Count == 0;
+    }
+
+    private List<SayVoice> EnsureVoices()
+    {
+        lock (_voiceLock)
+        {
+            _voices ??= ProbeVoices();
+            return _voices;
+        }
     }
 
     public void CancelSpeech()

--- a/BabySmash.Linux/Platform/MacOsTtsService.cs
+++ b/BabySmash.Linux/Platform/MacOsTtsService.cs
@@ -72,9 +72,9 @@ public class MacOsTtsService : ITtsService, IDisposable
                 process.Dispose();
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            Console.WriteLine($"TTS error: {ex.Message}");
+            Console.WriteLine("Text-to-speech playback failed.");
         }
     }
 

--- a/BabySmash.Linux/Platform/PlatformInfo.cs
+++ b/BabySmash.Linux/Platform/PlatformInfo.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+
+namespace BabySmash.Linux.Platform;
+
+public static class PlatformInfo
+{
+    public static bool IsMacOs => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    public static string DisplayName => IsMacOs ? "macOS" : IsLinux ? "Linux" : "Desktop";
+}

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ BabySmash blocks most keyboard shortcuts, but **Windows touchpad gestures** (lik
 
 ### Installation
 
-1. Download the app bundle for your Mac, if it is available in the latest release:
+1. Download the app bundle for your Mac:
    - Apple Silicon (M1/M2/M3): `BabySmash-osx-arm64.app.zip`
    - Intel: `BabySmash-osx-x64.app.zip`
 2. Unzip it and drag `BabySmash.app` to Applications, or run it from the extracted folder.
 3. On first launch, macOS Gatekeeper may require right-clicking the app and choosing **Open**, or approving BabySmash in **System Settings → Privacy & Security**.
 
-macOS release assets, when present, are self-contained and use built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback. Current bundles are ad-hoc signed but not Developer ID signed or notarized. Until Developer ID signing and notarization are configured for releases, building from source is a fallback if macOS blocks the downloaded app.
+macOS release assets are self-contained and use built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback. Current bundles are ad-hoc signed but not Developer ID signed or notarized. Until Developer ID signing and notarization are configured for releases, building from source is a fallback if macOS blocks the downloaded app.
 
 BabySmash uses fullscreen mode on macOS, but it does not globally block system shortcuts such as Command+Tab, Mission Control, or Command+Q.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ As babies or children smash on the keyboard, colored shapes, letters and numbers
 - 🔤 Letters and numbers with text-to-speech
 - 🔊 Fun sounds and giggles
 - 🖥️ Multi-monitor support
-- 🔒 Locks out system keys to prevent accidental exits
+- 🔒 Locks out system keys on Windows to prevent accidental exits
 - 🔄 **Auto-updates** via GitHub Releases (Windows)
 - 🐧 **Linux support** via Avalonia
 - 🍎 **macOS support** via Avalonia

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ As babies or children smash on the keyboard, colored shapes, letters and numbers
 | **Windows** | `winget install Hanselman.BabySmash` | Windows Package Manager |
 | **Windows** | [BabySmash-Setup.exe](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-Setup.exe) | Installer with auto-updates |
 | **Windows** | [BabySmash-win-x64.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-win-x64.zip) | Portable version |
-| **macOS Apple Silicon** | [BabySmash-osx-arm64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-arm64.app.zip) | Minimal app bundle, ad-hoc signed |
-| **macOS Intel** | [BabySmash-osx-x64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-x64.app.zip) | Minimal app bundle, ad-hoc signed |
+| **macOS Apple Silicon** | [BabySmash-osx-arm64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-arm64.app.zip) | Ad-hoc signed app bundle; may require right-click Open |
+| **macOS Intel** | [BabySmash-osx-x64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-x64.app.zip) | Ad-hoc signed app bundle; may require right-click Open |
 | **Debian/Ubuntu** | [.deb package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |
 | **Fedora/RHEL** | [.rpm package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |
 | **Linux** | [BabySmash-linux-x64.tar.gz](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-linux-x64.tar.gz) | Manual installation |
@@ -63,13 +63,13 @@ BabySmash blocks most keyboard shortcuts, but **Windows touchpad gestures** (lik
 
 ### Installation
 
-1. Download the app bundle for your Mac:
+1. Download the app bundle for your Mac, if it is available in the latest release:
    - Apple Silicon (M1/M2/M3): `BabySmash-osx-arm64.app.zip`
    - Intel: `BabySmash-osx-x64.app.zip`
 2. Unzip it and drag `BabySmash.app` to Applications, or run it from the extracted folder.
 3. On first launch, macOS Gatekeeper may require right-clicking the app and choosing **Open**, or approving BabySmash in **System Settings → Privacy & Security**.
 
-The macOS release is self-contained and uses built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback. Current release bundles are ad-hoc signed but not notarized.
+macOS release assets, when present, are self-contained and use built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback. Current bundles are ad-hoc signed but not Developer ID signed or notarized. Until Developer ID signing and notarization are configured for releases, building from source is a fallback if macOS blocks the downloaded app.
 
 BabySmash uses fullscreen mode on macOS, but it does not globally block system shortcuts such as Command+Tab, Mission Control, or Command+Q.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ As babies or children smash on the keyboard, colored shapes, letters and numbers
 - 🔒 Locks out system keys to prevent accidental exits
 - 🔄 **Auto-updates** via GitHub Releases (Windows)
 - 🐧 **Linux support** via Avalonia
+- 🍎 **macOS support** via Avalonia
 
 ## Downloads
 
@@ -23,6 +24,8 @@ As babies or children smash on the keyboard, colored shapes, letters and numbers
 | **Windows** | `winget install Hanselman.BabySmash` | Windows Package Manager |
 | **Windows** | [BabySmash-Setup.exe](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-Setup.exe) | Installer with auto-updates |
 | **Windows** | [BabySmash-win-x64.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-win-x64.zip) | Portable version |
+| **macOS Apple Silicon** | [BabySmash-osx-arm64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-arm64.app.zip) | Minimal app bundle, ad-hoc signed |
+| **macOS Intel** | [BabySmash-osx-x64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-x64.app.zip) | Minimal app bundle, ad-hoc signed |
 | **Debian/Ubuntu** | [.deb package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |
 | **Fedora/RHEL** | [.rpm package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |
 | **Linux** | [BabySmash-linux-x64.tar.gz](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-linux-x64.tar.gz) | Manual installation |
@@ -53,6 +56,36 @@ BabySmash blocks most keyboard shortcuts, but **Windows touchpad gestures** (lik
 1. Open **Windows Settings** → **Bluetooth & devices** → **Touchpad**
 2. Under **Three-finger gestures**, set "Swipes" to **Nothing**
 3. Optionally disable four-finger gestures too
+
+---
+
+## macOS
+
+### Installation
+
+1. Download the app bundle for your Mac:
+   - Apple Silicon (M1/M2/M3): `BabySmash-osx-arm64.app.zip`
+   - Intel: `BabySmash-osx-x64.app.zip`
+2. Unzip it and drag `BabySmash.app` to Applications, or run it from the extracted folder.
+3. On first launch, macOS Gatekeeper may require right-clicking the app and choosing **Open**, or approving BabySmash in **System Settings → Privacy & Security**.
+
+The macOS release is self-contained and uses built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback. Current release bundles are ad-hoc signed but not notarized.
+
+BabySmash uses fullscreen mode on macOS, but it does not globally block system shortcuts such as Command+Tab, Mission Control, or Command+Q.
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| Any key | Display shapes/letters! |
+| `Alt+O` | Options dialog |
+| `Escape` | Exit |
+
+### Requirements
+
+- macOS 12 or later
+- Apple Silicon (`osx-arm64`) or Intel (`osx-x64`)
+- No .NET installation required (self-contained)
 
 ---
 
@@ -187,7 +220,7 @@ cd babysmash
 # Windows
 dotnet run
 
-# Linux
+# Linux/macOS Avalonia frontend
 dotnet run --project BabySmash.Linux
 ```
 
@@ -199,6 +232,10 @@ dotnet publish -c Release -r win-x64 --self-contained
 
 # Linux
 dotnet publish BabySmash.Linux -c Release -r linux-x64 --self-contained
+
+# macOS
+dotnet publish BabySmash.Linux -c Release -r osx-arm64 --self-contained
+dotnet publish BabySmash.Linux -c Release -r osx-x64 --self-contained
 ```
 
 ---
@@ -210,6 +247,7 @@ Originally developed by [Scott Hanselman](https://www.hanselman.com), based on A
 - **v1-v2**: Original .NET Framework 3.5 version
 - **v3.0**: Migrated to .NET 10, single-file deployment
 - **v4.0**: Linux support via Avalonia, shared resources, auto-updates
+- **v5.0**: macOS support via Avalonia
 
 > **Looking for the original code?** The legacy .NET Framework 3.5 version is preserved in the [legacy-dotnet35](https://github.com/shanselman/babysmash/tree/legacy-dotnet35) branch.
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ As babies or children smash on the keyboard, colored shapes, letters and numbers
 | **Windows** | `winget install Hanselman.BabySmash` | Windows Package Manager |
 | **Windows** | [BabySmash-Setup.exe](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-Setup.exe) | Installer with auto-updates |
 | **Windows** | [BabySmash-win-x64.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-win-x64.zip) | Portable version |
-| **macOS Apple Silicon** | [BabySmash-osx-arm64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-arm64.app.zip) | Ad-hoc signed app bundle; may require right-click Open |
-| **macOS Intel** | [BabySmash-osx-x64.app.zip](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-osx-x64.app.zip) | Ad-hoc signed app bundle; may require right-click Open |
 | **Debian/Ubuntu** | [.deb package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |
 | **Fedora/RHEL** | [.rpm package](https://github.com/shanselman/babysmash/releases/latest) | Easy install with package manager |
 | **Linux** | [BabySmash-linux-x64.tar.gz](https://github.com/shanselman/babysmash/releases/latest/download/BabySmash-linux-x64.tar.gz) | Manual installation |
@@ -63,15 +61,19 @@ BabySmash blocks most keyboard shortcuts, but **Windows touchpad gestures** (lik
 
 ### Installation
 
-1. Download the app bundle for your Mac:
-   - Apple Silicon (M1/M2/M3): `BabySmash-osx-arm64.app.zip`
-   - Intel: `BabySmash-osx-x64.app.zip`
-2. Unzip it and drag `BabySmash.app` to Applications, or run it from the extracted folder.
-3. On first launch, macOS Gatekeeper may require right-clicking the app and choosing **Open**, or approving BabySmash in **System Settings → Privacy & Security**.
+BabySmash for macOS is currently build-validated and source-only: CI builds app bundles as build artifacts on every release tag, but there is no public release download until Developer ID signing and notarization are configured.
 
-macOS release assets are self-contained and use built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback. Current bundles are ad-hoc signed but not Developer ID signed or notarized. Until Developer ID signing and notarization are configured for releases, building from source is a fallback if macOS blocks the downloaded app.
+Build and run from source:
 
-BabySmash uses fullscreen mode on macOS, but it does not globally block system shortcuts such as Command+Tab, Mission Control, or Command+Q.
+```bash
+dotnet publish BabySmash.Linux/BabySmash.Linux.csproj -c Release -r osx-arm64 --self-contained
+```
+
+(Substitute `osx-x64` for Intel Macs.)
+
+It uses the built-in `/usr/bin/say` for text-to-speech and `/usr/bin/afplay` for sound playback.
+
+BabySmash uses borderless, per-display windows on macOS, but it does not globally block system shortcuts such as Command+Tab, Mission Control, or Command+Q.
 
 ### Keyboard Shortcuts
 
@@ -83,9 +85,9 @@ BabySmash uses fullscreen mode on macOS, but it does not globally block system s
 
 ### Requirements
 
-- macOS 12 or later
+- macOS 14 or later
 - Apple Silicon (`osx-arm64`) or Intel (`osx-x64`)
-- No .NET installation required (self-contained)
+- .NET 10 SDK (for building from source)
 
 ---
 


### PR DESCRIPTION
## Summary
- add macOS support to the existing Avalonia desktop app with platform-specific audio, text-to-speech, settings, and fullscreen behavior
- publish macOS `.app.zip` artifacts for Apple Silicon and Intel alongside the existing Windows and Linux outputs
- document macOS installation, Gatekeeper behavior, and the current ad-hoc signing/notarization status

## Validation
- `dotnet build BabySmash.Linux/BabySmash.Linux.csproj -c Release --no-restore`
- `dotnet publish BabySmash.Linux/BabySmash.Linux.csproj -c Release -r linux-x64 --self-contained`
- `dotnet publish BabySmash.Linux/BabySmash.Linux.csproj -c Release -r osx-arm64 --self-contained`
- `dotnet publish BabySmash.Linux/BabySmash.Linux.csproj -c Release -r osx-x64 --self-contained`
- GitHub Actions run passed: https://github.com/cristhiank/babysmash/actions/runs/26703451050

## Notes
- Windows WPF remains unchanged as the Windows app path.
- macOS bundles are currently ad-hoc signed, not Developer ID signed or notarized; README now documents the Gatekeeper implications and source-build fallback.