### PR TITLE
fix(linux): disable screenshot hotkey

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -228,6 +228,7 @@ namespace BabySmash
             // F4 alone triggers Properties command in Windows - kids hit it accidentally
             if (key <= Keys.Back || key == Keys.None ||
                 key == Keys.Menu || key == Keys.Pause ||
+                key == Keys.PrintScreen ||
                 key == Keys.Help || key == Keys.F4)
             {
                 return false;

--- a/BabySmash.Linux/App.axaml.cs
+++ b/BabySmash.Linux/App.axaml.cs
@@ -40,6 +40,8 @@ public partial class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            desktop.Exit += (_, _) => Services.GetRequiredService<IKeyboardHookService>().Stop();
+
             // Create first window to get screen info
             var firstWindow = new MainWindow();
             desktop.MainWindow = firstWindow;

--- a/BabySmash.Linux/BabySmash.Linux.csproj
+++ b/BabySmash.Linux/BabySmash.Linux.csproj
@@ -28,8 +28,8 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="12.0.5" />
     <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.18">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/BabySmash.Linux/Core/Interfaces/IKeyboardHookService.cs
+++ b/BabySmash.Linux/Core/Interfaces/IKeyboardHookService.cs
@@ -12,6 +12,8 @@ public interface IKeyboardHookService
 {
     event EventHandler<KeyboardHookEventArgs>? KeyPressed;
     bool Start();
+    void DisableSystemScreenshotShortcut();
+    void RestoreSystemScreenshotShortcut();
     void Stop();
     bool IsActive { get; }
 }

--- a/BabySmash.Linux/MainWindow.axaml.cs
+++ b/BabySmash.Linux/MainWindow.axaml.cs
@@ -10,7 +10,6 @@ using Avalonia.Threading;
 using BabySmash.Linux.Core.Interfaces;
 using BabySmash.Linux.Core.Models;
 using BabySmash.Linux.Core.Services;
-using BabySmash.Linux.Platform;
 using BabySmash.Linux.Shapes;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,7 +20,7 @@ public partial class MainWindow : Window
     private readonly ITtsService _ttsService;
     private readonly IAudioService _audioService;
     private readonly ISettingsService _settingsService;
-    private readonly LinuxKeyboardHookService? _keyboardHookService;
+    private readonly IKeyboardHookService _keyboardHookService;
     private readonly WordFinder _wordFinder;
     private readonly Queue<Control> _figuresQueue = new();
     private readonly Queue<Shape> _mouseEllipsesQueue = new();
@@ -40,7 +39,7 @@ public partial class MainWindow : Window
         _ttsService = App.Services.GetRequiredService<ITtsService>();
         _audioService = App.Services.GetRequiredService<IAudioService>();
         _settingsService = App.Services.GetRequiredService<ISettingsService>();
-        _keyboardHookService = App.Services.GetRequiredService<IKeyboardHookService>() as LinuxKeyboardHookService;
+        _keyboardHookService = App.Services.GetRequiredService<IKeyboardHookService>();
         _wordFinder = App.Services.GetRequiredService<WordFinder>();
         
         // Hook up input events
@@ -76,12 +75,12 @@ public partial class MainWindow : Window
         // Setup custom cursor
         SetupCustomCursor();
 
-        _keyboardHookService?.DisableSystemScreenshotShortcut();
+        _keyboardHookService.DisableSystemScreenshotShortcut();
     }
 
     private void OnClosed(object? sender, EventArgs e)
     {
-        _keyboardHookService?.RestoreSystemScreenshotShortcut();
+        _keyboardHookService.RestoreSystemScreenshotShortcut();
     }
 
     private void SetupCustomCursor()

--- a/BabySmash.Linux/MainWindow.axaml.cs
+++ b/BabySmash.Linux/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Threading;
 using BabySmash.Linux.Core.Interfaces;
 using BabySmash.Linux.Core.Models;
 using BabySmash.Linux.Core.Services;
+using BabySmash.Linux.Platform;
 using BabySmash.Linux.Shapes;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,7 @@ public partial class MainWindow : Window
     private readonly ITtsService _ttsService;
     private readonly IAudioService _audioService;
     private readonly ISettingsService _settingsService;
+    private readonly LinuxKeyboardHookService? _keyboardHookService;
     private readonly WordFinder _wordFinder;
     private readonly Queue<Control> _figuresQueue = new();
     private readonly Queue<Shape> _mouseEllipsesQueue = new();
@@ -38,6 +40,7 @@ public partial class MainWindow : Window
         _ttsService = App.Services.GetRequiredService<ITtsService>();
         _audioService = App.Services.GetRequiredService<IAudioService>();
         _settingsService = App.Services.GetRequiredService<ISettingsService>();
+        _keyboardHookService = App.Services.GetRequiredService<IKeyboardHookService>() as LinuxKeyboardHookService;
         _wordFinder = App.Services.GetRequiredService<WordFinder>();
         
         // Hook up input events
@@ -59,6 +62,7 @@ public partial class MainWindow : Window
         };
         
         Loaded += OnLoaded;
+        Closed += OnClosed;
     }
 
     private void OnLoaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -71,6 +75,13 @@ public partial class MainWindow : Window
         
         // Setup custom cursor
         SetupCustomCursor();
+
+        _keyboardHookService?.DisableSystemScreenshotShortcut();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        _keyboardHookService?.RestoreSystemScreenshotShortcut();
     }
 
     private void SetupCustomCursor()
@@ -90,6 +101,12 @@ public partial class MainWindow : Window
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
     {
+        if (IsSystemShortcutKey(e.Key))
+        {
+            e.Handled = true;
+            return;
+        }
+
         // Hide info label on first keypress
         var infoLabel = this.FindControl<StackPanel>("infoLabel");
         if (infoLabel != null && infoLabel.IsVisible)
@@ -155,6 +172,11 @@ public partial class MainWindow : Window
         }
 
         e.Handled = true;
+    }
+
+    private static bool IsSystemShortcutKey(Key key)
+    {
+        return key == Key.Print || key == Key.Snapshot;
     }
 
     private void CloseAllWindows()

--- a/BabySmash.Linux/Platform/LinuxKeyboardHookService.cs
+++ b/BabySmash.Linux/Platform/LinuxKeyboardHookService.cs
@@ -2,21 +2,40 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using BabySmash.Linux.Core.Interfaces;
 
 namespace BabySmash.Linux.Platform;
 
 public sealed class LinuxKeyboardHookService : IKeyboardHookService
 {
+    private const int GSettingsTimeoutMilliseconds = 1000;
+    private const int ShutdownWaitMilliseconds = 5000;
+
     private static readonly GSettingsKey[] ScreenshotShortcutKeys =
     [
         new("org.cinnamon.desktop.keybindings.media-keys", "screenshot"),
         new("org.gnome.settings-daemon.plugins.media-keys", "screenshot")
     ];
 
-    private readonly Dictionary<GSettingsKey, string> _disabledShortcuts = new();
+    private readonly object _operationLock = new();
+    private readonly string _shortcutBackupPath;
+    private Task _shortcutOperation = Task.CompletedTask;
     private int _activeWindows;
+    private volatile bool _shutdownRequested;
+
+    public LinuxKeyboardHookService()
+    {
+        var configDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".config",
+            "babysmash");
+        Directory.CreateDirectory(configDirectory);
+        _shortcutBackupPath = Path.Combine(configDirectory, "screenshot-shortcuts.json");
+    }
 
     public event EventHandler<KeyboardHookEventArgs> KeyPressed;
 
@@ -32,30 +51,55 @@ public sealed class LinuxKeyboardHookService : IKeyboardHookService
     {
         Start();
 
-        if (_activeWindows++ == 0)
+        lock (_operationLock)
         {
-            DisableDesktopScreenshotShortcuts();
+            if (_activeWindows++ == 0)
+            {
+                QueueShortcutOperation(DisableDesktopScreenshotShortcuts);
+            }
         }
     }
 
     public void RestoreSystemScreenshotShortcut()
     {
-        if (_activeWindows > 0)
+        lock (_operationLock)
         {
-            _activeWindows--;
-        }
+            if (_activeWindows > 0)
+            {
+                _activeWindows--;
+            }
 
-        if (_activeWindows == 0)
-        {
-            RestoreDesktopScreenshotShortcuts();
+            if (_activeWindows == 0)
+            {
+                QueueShortcutOperation(() => RestoreDesktopScreenshotShortcuts());
+            }
         }
     }
 
     public void Stop()
     {
-        _activeWindows = 0;
-        RestoreDesktopScreenshotShortcuts();
-        IsActive = false;
+        Task shortcutOperation;
+
+        lock (_operationLock)
+        {
+            _shutdownRequested = true;
+            _activeWindows = 0;
+            QueueShortcutOperation(() => RestoreDesktopScreenshotShortcuts());
+            shortcutOperation = _shortcutOperation;
+            IsActive = false;
+        }
+
+        try
+        {
+            if (!shortcutOperation.Wait(ShutdownWaitMilliseconds))
+            {
+                Console.Error.WriteLine("Timed out while restoring screenshot shortcuts.");
+            }
+        }
+        catch (AggregateException exception)
+        {
+            Console.Error.WriteLine($"Could not restore screenshot shortcuts during shutdown: {exception.GetBaseException().Message}");
+        }
     }
 
     public void SimulateKeyPress(char character)
@@ -69,11 +113,19 @@ public sealed class LinuxKeyboardHookService : IKeyboardHookService
 
     private void DisableDesktopScreenshotShortcuts()
     {
+        if (!RestoreDesktopScreenshotShortcuts())
+        {
+            Console.Error.WriteLine("Could not restore the previous screenshot shortcut backup; shortcuts were not changed.");
+            return;
+        }
+
+        var shortcutsToDisable = new List<GSettingsBackup>();
+
         foreach (var shortcut in ScreenshotShortcutKeys)
         {
-            if (_disabledShortcuts.ContainsKey(shortcut) || !GSettingsKeyExists(shortcut))
+            if (_shutdownRequested)
             {
-                continue;
+                return;
             }
 
             var currentValue = RunGSettings("get", shortcut.Schema, shortcut.Name);
@@ -82,27 +134,121 @@ public sealed class LinuxKeyboardHookService : IKeyboardHookService
                 continue;
             }
 
-            if (RunGSettings("set", shortcut.Schema, shortcut.Name, "[]") is not null)
+            shortcutsToDisable.Add(new GSettingsBackup(shortcut.Schema, shortcut.Name, currentValue.Trim()));
+        }
+
+        if (shortcutsToDisable.Count == 0 || !SaveShortcutBackup(shortcutsToDisable))
+        {
+            return;
+        }
+
+        if (_shutdownRequested)
+        {
+            RestoreDesktopScreenshotShortcuts();
+            return;
+        }
+
+        foreach (var shortcut in shortcutsToDisable)
+        {
+            if (_shutdownRequested)
             {
-                _disabledShortcuts[shortcut] = currentValue.Trim();
+                RestoreDesktopScreenshotShortcuts();
+                return;
+            }
+
+            if (RunGSettings("set", shortcut.Schema, shortcut.Name, "[]") is null)
+            {
+                Console.Error.WriteLine($"Could not disable screenshot shortcut {shortcut.Schema}/{shortcut.Name}.");
+                RestoreDesktopScreenshotShortcuts();
+                return;
             }
         }
     }
 
-    private void RestoreDesktopScreenshotShortcuts()
+    private bool RestoreDesktopScreenshotShortcuts()
     {
-        foreach (var shortcut in _disabledShortcuts)
+        if (!File.Exists(_shortcutBackupPath))
         {
-            RunGSettings("set", shortcut.Key.Schema, shortcut.Key.Name, shortcut.Value);
+            return true;
         }
 
-        _disabledShortcuts.Clear();
+        try
+        {
+            var json = File.ReadAllText(_shortcutBackupPath);
+            var shortcuts = JsonSerializer.Deserialize<List<GSettingsBackup>>(json);
+            if (shortcuts is null)
+            {
+                Console.Error.WriteLine("Screenshot shortcut backup is invalid; leaving it in place for recovery.");
+                return false;
+            }
+
+            var shortcutsNotRestored = new List<GSettingsBackup>();
+
+            foreach (var shortcut in shortcuts)
+            {
+                if (RunGSettings("set", shortcut.Schema, shortcut.Name, shortcut.Value) is null)
+                {
+                    Console.Error.WriteLine($"Could not restore screenshot shortcut {shortcut.Schema}/{shortcut.Name}.");
+                    shortcutsNotRestored.Add(shortcut);
+                }
+            }
+
+            if (shortcutsNotRestored.Count > 0)
+            {
+                SaveShortcutBackup(shortcutsNotRestored);
+                return false;
+            }
+
+            File.Delete(_shortcutBackupPath);
+            return true;
+        }
+        catch (IOException exception)
+        {
+            Console.Error.WriteLine($"Could not restore screenshot shortcuts: {exception.Message}");
+            return false;
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            Console.Error.WriteLine($"Could not restore screenshot shortcuts: {exception.Message}");
+            return false;
+        }
+        catch (JsonException exception)
+        {
+            Console.Error.WriteLine($"Could not read screenshot shortcut backup: {exception.Message}");
+            return false;
+        }
     }
 
-    private static bool GSettingsKeyExists(GSettingsKey shortcut)
+    private bool SaveShortcutBackup(List<GSettingsBackup> shortcuts)
     {
-        var keys = RunGSettings("list-keys", shortcut.Schema);
-        return keys?.Split('\n').Contains(shortcut.Name) == true;
+        var temporaryPath = $"{_shortcutBackupPath}.tmp";
+
+        try
+        {
+            var json = JsonSerializer.Serialize(shortcuts, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(temporaryPath, json);
+            File.Move(temporaryPath, _shortcutBackupPath, true);
+            return true;
+        }
+        catch (IOException exception)
+        {
+            Console.Error.WriteLine($"Could not save screenshot shortcut backup: {exception.Message}");
+            return false;
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            Console.Error.WriteLine($"Could not save screenshot shortcut backup: {exception.Message}");
+            return false;
+        }
+    }
+
+    private void QueueShortcutOperation(Action operation)
+    {
+        _shortcutOperation = _shortcutOperation.ContinueWith(
+            _ => operation(),
+            CancellationToken.None,
+            TaskContinuationOptions.None,
+            TaskScheduler.Default);
     }
 
     private static string? RunGSettings(params string[] arguments)
@@ -112,8 +258,10 @@ public sealed class LinuxKeyboardHookService : IKeyboardHookService
             var startInfo = new ProcessStartInfo
             {
                 FileName = "gsettings",
+                CreateNoWindow = true,
                 RedirectStandardError = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                UseShellExecute = false
             };
 
             foreach (var argument in arguments)
@@ -127,14 +275,53 @@ public sealed class LinuxKeyboardHookService : IKeyboardHookService
                 return null;
             }
 
-            process.WaitForExit();
-            return process.ExitCode == 0 ? process.StandardOutput.ReadToEnd() : null;
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit(GSettingsTimeoutMilliseconds))
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(GSettingsTimeoutMilliseconds);
+                Console.Error.WriteLine($"gsettings timed out: {string.Join(' ', arguments)}");
+                return null;
+            }
+
+            if (!Task.WaitAll([outputTask, errorTask], GSettingsTimeoutMilliseconds))
+            {
+                Console.Error.WriteLine($"Timed out while reading gsettings output: {string.Join(' ', arguments)}");
+                return null;
+            }
+
+            var output = outputTask.GetAwaiter().GetResult();
+            var error = errorTask.GetAwaiter().GetResult();
+            if (process.ExitCode != 0)
+            {
+                if (!string.IsNullOrWhiteSpace(error))
+                {
+                    Console.Error.WriteLine(error.Trim());
+                }
+                return null;
+            }
+
+            return output;
         }
-        catch (Win32Exception)
+        catch (Win32Exception exception)
         {
+            Console.Error.WriteLine($"Could not run gsettings: {exception.Message}");
+            return null;
+        }
+        catch (InvalidOperationException exception)
+        {
+            Console.Error.WriteLine($"Could not run gsettings: {exception.Message}");
+            return null;
+        }
+        catch (AggregateException exception)
+        {
+            Console.Error.WriteLine($"Could not read gsettings output: {exception.GetBaseException().Message}");
             return null;
         }
     }
 
     private readonly record struct GSettingsKey(string Schema, string Name);
+    private sealed record GSettingsBackup(string Schema, string Name, string Value);
 }

--- a/BabySmash.Linux/Platform/LinuxKeyboardHookService.cs
+++ b/BabySmash.Linux/Platform/LinuxKeyboardHookService.cs
@@ -1,33 +1,140 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
 using BabySmash.Linux.Core.Interfaces;
 
 namespace BabySmash.Linux.Platform;
 
-public class LinuxKeyboardHookService : IKeyboardHookService
+public sealed class LinuxKeyboardHookService : IKeyboardHookService
 {
+    private static readonly GSettingsKey[] ScreenshotShortcutKeys =
+    [
+        new("org.cinnamon.desktop.keybindings.media-keys", "screenshot"),
+        new("org.gnome.settings-daemon.plugins.media-keys", "screenshot")
+    ];
+
+    private readonly Dictionary<GSettingsKey, string> _disabledShortcuts = new();
+    private int _activeWindows;
+
     public event EventHandler<KeyboardHookEventArgs> KeyPressed;
-    
+
     public bool IsActive { get; private set; }
 
     public bool Start()
     {
-        // TODO: Implement X11/Wayland keyboard hooks
         IsActive = true;
         return true;
     }
 
+    public void DisableSystemScreenshotShortcut()
+    {
+        Start();
+
+        if (_activeWindows++ == 0)
+        {
+            DisableDesktopScreenshotShortcuts();
+        }
+    }
+
+    public void RestoreSystemScreenshotShortcut()
+    {
+        if (_activeWindows > 0)
+        {
+            _activeWindows--;
+        }
+
+        if (_activeWindows == 0)
+        {
+            RestoreDesktopScreenshotShortcuts();
+        }
+    }
+
     public void Stop()
     {
+        _activeWindows = 0;
+        RestoreDesktopScreenshotShortcuts();
         IsActive = false;
     }
-    
-    // For now, we'll use Avalonia's normal keyboard events
+
     public void SimulateKeyPress(char character)
     {
-        KeyPressed?.Invoke(this, new KeyboardHookEventArgs 
-        { 
+        KeyPressed?.Invoke(this, new KeyboardHookEventArgs
+        {
             Character = character,
             VirtualKeyCode = character
         });
     }
+
+    private void DisableDesktopScreenshotShortcuts()
+    {
+        foreach (var shortcut in ScreenshotShortcutKeys)
+        {
+            if (_disabledShortcuts.ContainsKey(shortcut) || !GSettingsKeyExists(shortcut))
+            {
+                continue;
+            }
+
+            var currentValue = RunGSettings("get", shortcut.Schema, shortcut.Name);
+            if (string.IsNullOrWhiteSpace(currentValue) || currentValue.Trim() is "@as []" or "[]")
+            {
+                continue;
+            }
+
+            if (RunGSettings("set", shortcut.Schema, shortcut.Name, "[]") is not null)
+            {
+                _disabledShortcuts[shortcut] = currentValue.Trim();
+            }
+        }
+    }
+
+    private void RestoreDesktopScreenshotShortcuts()
+    {
+        foreach (var shortcut in _disabledShortcuts)
+        {
+            RunGSettings("set", shortcut.Key.Schema, shortcut.Key.Name, shortcut.Value);
+        }
+
+        _disabledShortcuts.Clear();
+    }
+
+    private static bool GSettingsKeyExists(GSettingsKey shortcut)
+    {
+        var keys = RunGSettings("list-keys", shortcut.Schema);
+        return keys?.Split('\n').Contains(shortcut.Name) == true;
+    }
+
+    private static string? RunGSettings(params string[] arguments)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "gsettings",
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return null;
+            }
+
+            process.WaitForExit();
+            return process.ExitCode == 0 ? process.StandardOutput.ReadToEnd() : null;
+        }
+        catch (Win32Exception)
+        {
+            return null;
+        }
+    }
+
+    private readonly record struct GSettingsKey(string Schema, string Name);
 }


### PR DESCRIPTION
prevents screenshot utility from opening and taking focus over from the app on linux when a dedicated key exists. Tested on lenovo yoga 3rd generation running linux mint 22.3