### PR TITLE
ci: adds a dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "BabySmash (.NET)",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0-noble",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "containerEnv": {
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+    "DOTNET_NOLOGO": "1"
+  },
+  "postCreateCommand": "dotnet restore BabySmash.Linux/BabySmash.Linux.csproj",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp"
+      ]
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: devcontainers
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
   - package-ecosystem: dotnet-sdk
     directory: /
     schedule:


### PR DESCRIPTION
the dev container makes building on multiple environments easier without having to install dotnet