### PR TITLE
Upgrade Avalonia package family to 12.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    groups:
+      avalonia:
+        patterns:
+          - "Avalonia*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/BabySmash.Linux/BabySmash.Linux.csproj
+++ b/BabySmash.Linux/BabySmash.Linux.csproj
@@ -26,10 +26,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
+    <PackageReference Include="Avalonia" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.1" />
+    <!-- Avalonia.Diagnostics has no 12.x release; 11.3.20 is its latest stable version. -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.20">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/BabySmash.Linux/MainWindow.axaml
+++ b/BabySmash.Linux/MainWindow.axaml
@@ -5,7 +5,7 @@
         Background="WhiteSmoke"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
-        SystemDecorations="None"
+        WindowDecorations="None"
         Topmost="True">
     
     <Grid>


### PR DESCRIPTION
## Summary
- upgrade `Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, and `Avalonia.Fonts.Inter` together to 12.1.1
- retain `Avalonia.Diagnostics` 11.3.20 because it is the latest stable published line and no 12.x package exists
- replace obsolete `SystemDecorations` with `WindowDecorations`
- group future `Avalonia*` Dependabot updates into one pull request
- rely on transitive `Tmds.DBus.Protocol` 0.94.1; no explicit pin is needed and NuGet reports no vulnerable packages

## Validation
- Linux x64 restore
- Debug Linux x64 build: 0 warnings, 0 errors
- Release Linux x64 build: 0 warnings, 0 errors
- self-contained Release Linux x64 publish
- direct and transitive NuGet vulnerability audit

Manual Linux smoke testing remains for launch/fullscreen, input and animations, audio/TTS, settings, and multi-monitor behavior.

Fixes #136