### PR TITLE
Fix kiosk locking and Options shortcut

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -196,7 +196,10 @@ namespace BabySmash
         private static void DetachKeyboardHook()
         {
             if (_hookID != IntPtr.Zero)
+            {
                 InterceptKeys.UnhookWindowsHookEx(_hookID);
+                _hookID = IntPtr.Zero;
+            }
         }
 
         public static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
@@ -215,16 +218,30 @@ namespace BabySmash
                 if (alt && key == Keys.F4 &&
                     (message == WmKeyDown || message == WmSysKeyDown))
                 {
-                    Application.Current.Shutdown();
+                    Application.Current?.Shutdown();
                     return (IntPtr)1; // Handled.
                 }
 
                 if ((message == WmKeyDown || message == WmSysKeyDown) &&
-                    !IsOptionsGestureKey(key))
+                    !IsOptionsGestureKey(key) &&
+                    Controller.Instance.HasActiveOptionsGesture)
                 {
-                    Application.Current.Dispatcher.BeginInvoke(
-                        DispatcherPriority.Input,
-                        new Action(Controller.Instance.CancelOptionsGesture));
+                    Dispatcher dispatcher = Application.Current?.Dispatcher;
+                    if (dispatcher != null &&
+                        !dispatcher.HasShutdownStarted &&
+                        !dispatcher.HasShutdownFinished)
+                    {
+                        try
+                        {
+                            dispatcher.BeginInvoke(
+                                DispatcherPriority.Input,
+                                new Action(Controller.Instance.CancelOptionsGesture));
+                        }
+                        catch (InvalidOperationException ex)
+                        {
+                            Debug.WriteLine($"Unable to cancel Options gesture during shutdown: {ex.Message}");
+                        }
+                    }
                 }
 
                 if (!AllowKeyboardInput(alt, control, key))

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Media;
+using System.Windows.Threading;
 using BabySmash.Properties;
 using Updatum;
 using Application = System.Windows.Application;
@@ -218,6 +219,14 @@ namespace BabySmash
                     return (IntPtr)1; // Handled.
                 }
 
+                if ((message == WmKeyDown || message == WmSysKeyDown) &&
+                    !IsOptionsGestureKey(key))
+                {
+                    Application.Current.Dispatcher.BeginInvoke(
+                        DispatcherPriority.Input,
+                        new Action(Controller.Instance.CancelOptionsGesture));
+                }
+
                 if (!AllowKeyboardInput(alt, control, key))
                 {
                     return (IntPtr)1; // Handled.
@@ -225,6 +234,14 @@ namespace BabySmash
             }
 
             return InterceptKeys.CallNextHookEx(_hookID, nCode, wParam, lParam);
+        }
+
+        private static bool IsOptionsGestureKey(Keys key)
+        {
+            return key == Keys.O ||
+                   key == Keys.ControlKey || key == Keys.LControlKey || key == Keys.RControlKey ||
+                   key == Keys.Menu || key == Keys.LMenu || key == Keys.RMenu ||
+                   key == Keys.ShiftKey || key == Keys.LShiftKey || key == Keys.RShiftKey;
         }
 
         /// <summary>Determines whether the specified keyboard input should be allowed to be processed by the system.</summary>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -17,6 +17,9 @@ namespace BabySmash
 {
     public partial class App : Application
     {
+        private const int WmKeyDown = 0x0100;
+        private const int WmSysKeyDown = 0x0104;
+        private const int LlkhfAltDown = 0x20;
         private static readonly InterceptKeys.LowLevelKeyboardProc _proc = HookCallback;
         private static IntPtr _hookID = IntPtr.Zero;
         private static Mutex _singleInstanceMutex;
@@ -199,13 +202,17 @@ namespace BabySmash
         {
             if (nCode >= 0)
             {
-                bool alt = (WinForms.Control.ModifierKeys & Keys.Alt) != 0;
+                int message = wParam.ToInt32();
+                int flags = Marshal.ReadInt32(lParam, 8);
+                bool alt = (flags & LlkhfAltDown) != 0 ||
+                           (WinForms.Control.ModifierKeys & Keys.Alt) != 0;
                 bool control = (WinForms.Control.ModifierKeys & Keys.Control) != 0;
 
                 int vkCode = Marshal.ReadInt32(lParam);
                 Keys key = (Keys)vkCode;
 
-                if (alt && key == Keys.F4)
+                if (alt && key == Keys.F4 &&
+                    (message == WmKeyDown || message == WmSysKeyDown))
                 {
                     Application.Current.Shutdown();
                     return (IntPtr)1; // Handled.

--- a/Controller.cs
+++ b/Controller.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
@@ -37,6 +38,19 @@ namespace BabySmash
         [DllImport("user32.dll")]
         private static extern bool SetForegroundWindow(IntPtr hWnd);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SetWindowPos(
+            IntPtr hWnd,
+            IntPtr hWndInsertAfter,
+            int x,
+            int y,
+            int width,
+            int height,
+            uint flags);
+
+        private const uint SwpNoZOrder = 0x0004;
+        private const uint SwpNoActivate = 0x0010;
+
         private static Controller instance = new Controller();
 
         public static bool ShowFps { get; set; }
@@ -44,6 +58,8 @@ namespace BabySmash
         public bool isOptionsDialogShown { get; set; }
         private bool isDrawing = false;
         private readonly List<MainWindow> windows = new List<MainWindow>();
+        private readonly Dictionary<MainWindow, WinForms.Screen> windowScreens = new Dictionary<MainWindow, WinForms.Screen>();
+        private bool isRestoringKioskState;
         private readonly SpeechQueue _speechQueue = new SpeechQueue(5);
 
         private DispatcherTimer timer = new DispatcherTimer();
@@ -89,12 +105,14 @@ namespace BabySmash
                 };
 
                 figuresUserControlQueue[m.Name] = new List<UserControl>();
+                windows.Add(m);
+                windowScreens[m] = s;
 
                 m.Show();
+                PositionWindowOnScreen(m, s);
                 m.MouseLeftButtonDown += HandleMouseLeftButtonDown;
                 m.MouseWheel += HandleMouseWheel;
                 m.WindowState = WindowState.Maximized;
-                windows.Add(m);
             }
 
             //Only show the info label on the FIRST monitor.
@@ -110,21 +128,7 @@ namespace BabySmash
 
         void timer_Tick(object sender, EventArgs e)
         {
-            if (isOptionsDialogShown)
-            {
-                return;
-            }
-
-            try
-            {
-                IntPtr windowHandle = new WindowInteropHelper(Application.Current.MainWindow).Handle;
-                SetForegroundWindow(windowHandle);
-                SetFocus(windowHandle);
-            }
-            catch (Exception)
-            {
-                //Wish me luck!
-            }
+            RestoreKioskState();
         }
 
         public void ProcessKey(FrameworkElement uie, KeyEventArgs e)
@@ -433,35 +437,134 @@ namespace BabySmash
 
         public void ShowOptionsDialog()
         {
-            bool foo = Settings.Default.TransparentBackground;
-            isOptionsDialogShown = true;
-            var o = new Options();
-            Mouse.Capture(null);
-            foreach (MainWindow m in this.windows)
+            if (isOptionsDialogShown || windows.Count == 0)
             {
-                m.Topmost = false;
+                return;
             }
-            o.Topmost = true;
-            o.Focus();
-            o.ShowDialog();
-            Debug.Write("test");
-            foreach (MainWindow m in this.windows)
-            {
-                m.Topmost = true;
-                //m.ResetCanvas();
-            }
-            isOptionsDialogShown = false;
 
-            if (foo != Settings.Default.TransparentBackground)
+            bool transparentBackground = Settings.Default.TransparentBackground;
+            isOptionsDialogShown = true;
+            try
             {
-                MessageBoxResult result = MessageBox.Show(
+                var options = new Options
+                {
+                    Owner = windows[0],
+                    Topmost = true
+                };
+
+                Mouse.Capture(null);
+                foreach (MainWindow window in windows)
+                {
+                    window.Topmost = false;
+                    window.CustomCursor.Visibility = Visibility.Hidden;
+                }
+
+                options.ShowDialog();
+
+                if (transparentBackground != Settings.Default.TransparentBackground)
+                {
+                    RestoreKioskStateCore(restoreCursor: false);
+                    MessageBoxResult result = MessageBox.Show(
+                        windows[0],
                         "You've changed the Window Transparency Option. We'll need to restart BabySmash! for you to see the change. Pressing YES will restart BabySmash!. Is that OK?",
                         "Need to Restart", MessageBoxButton.YesNo, MessageBoxImage.Question);
-                if (result == MessageBoxResult.Yes)
-                {
-                    Application.Current.Shutdown();
-                    System.Windows.Forms.Application.Restart();
+
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        Application.Current.Shutdown();
+                        System.Windows.Forms.Application.Restart();
+                    }
                 }
+            }
+            finally
+            {
+                isOptionsDialogShown = false;
+                RestoreKioskStateCore(restoreCursor: true);
+            }
+        }
+
+        public void RestoreKioskState()
+        {
+            if (isOptionsDialogShown)
+            {
+                return;
+            }
+
+            RestoreKioskStateCore(restoreCursor: false);
+        }
+
+        private void RestoreKioskStateCore(bool restoreCursor)
+        {
+            if (isRestoringKioskState || windows.Count == 0)
+            {
+                return;
+            }
+
+            isRestoringKioskState = true;
+            try
+            {
+                foreach (MainWindow window in windows)
+                {
+                    if (!window.IsLoaded)
+                    {
+                        continue;
+                    }
+
+                    window.WindowStyle = WindowStyle.None;
+                    window.ResizeMode = ResizeMode.NoResize;
+
+                    if (window.WindowState != WindowState.Maximized)
+                    {
+                        WinForms.Screen screen = windowScreens[window];
+                        window.WindowState = WindowState.Normal;
+                        PositionWindowOnScreen(window, screen);
+                        window.WindowState = WindowState.Maximized;
+                    }
+
+                    window.Topmost = true;
+                    if (restoreCursor)
+                    {
+                        window.RestoreCursor();
+                    }
+                }
+
+                MainWindow primaryWindow = windows[0];
+                if (!primaryWindow.IsLoaded)
+                {
+                    return;
+                }
+
+                primaryWindow.Activate();
+                Keyboard.Focus(primaryWindow);
+
+                IntPtr windowHandle = new WindowInteropHelper(primaryWindow).Handle;
+                if (windowHandle != IntPtr.Zero)
+                {
+                    SetForegroundWindow(windowHandle);
+                    SetFocus(windowHandle);
+                }
+            }
+            finally
+            {
+                isRestoringKioskState = false;
+            }
+        }
+
+        private static void PositionWindowOnScreen(MainWindow window, WinForms.Screen screen)
+        {
+            IntPtr handle = new WindowInteropHelper(window).Handle;
+            if (!SetWindowPos(
+                    handle,
+                    IntPtr.Zero,
+                    screen.Bounds.Left,
+                    screen.Bounds.Top,
+                    screen.Bounds.Width,
+                    screen.Bounds.Height,
+                    SwpNoZOrder | SwpNoActivate))
+            {
+                Debug.WriteLine(
+                    $"Failed to position {window.Name} on {screen.DeviceName}: " +
+                    new Win32Exception(Marshal.GetLastWin32Error()).Message);
             }
         }
 

--- a/Controller.cs
+++ b/Controller.cs
@@ -58,11 +58,11 @@ namespace BabySmash
         public bool isOptionsDialogShown { get; set; }
         private bool isDrawing = false;
         private readonly List<MainWindow> windows = new List<MainWindow>();
-        private readonly Dictionary<MainWindow, WinForms.Screen> windowScreens = new Dictionary<MainWindow, WinForms.Screen>();
+        private readonly Dictionary<MainWindow, string> windowScreenDeviceNames = new Dictionary<MainWindow, string>();
         private bool isRestoringKioskState;
         private readonly SpeechQueue _speechQueue = new SpeechQueue(5);
 
-        private DispatcherTimer timer = new DispatcherTimer();
+        private DispatcherTimer timer = new DispatcherTimer(DispatcherPriority.Normal);
         private Queue<Shape> ellipsesQueue = new Queue<Shape>();
         private Dictionary<string, List<UserControl>> figuresUserControlQueue = new Dictionary<string, List<UserControl>>();
         private WordFinder wordFinder = new WordFinder("Words.txt");
@@ -106,17 +106,22 @@ namespace BabySmash
 
                 figuresUserControlQueue[m.Name] = new List<UserControl>();
                 windows.Add(m);
-                windowScreens[m] = s;
+                windowScreenDeviceNames[m] = s.DeviceName;
 
                 m.Show();
                 PositionWindowOnScreen(m, s);
+                m.Closed += HandleWindowClosed;
                 m.MouseLeftButtonDown += HandleMouseLeftButtonDown;
                 m.MouseWheel += HandleMouseWheel;
                 m.WindowState = WindowState.Maximized;
             }
 
             //Only show the info label on the FIRST monitor.
-            windows[0].infoLabel.Visibility = Visibility.Visible;
+            MainWindow firstWindow = GetFirstLoadedWindow();
+            if (firstWindow != null)
+            {
+                firstWindow.infoLabel.Visibility = Visibility.Visible;
+            }
 
             //Startup sound
             Win32Audio.PlayWavResourceYield("EditedJackPlaysBabySmash.wav");
@@ -432,12 +437,16 @@ namespace BabySmash
 
         public void Shutdown()
         {
+            timer.Stop();
+            timer.Tick -= timer_Tick;
             _speechQueue.Dispose();
         }
 
         public void ShowOptionsDialog()
         {
-            if (isOptionsDialogShown || windows.Count == 0)
+            PruneClosedWindows();
+            MainWindow owner = GetFirstLoadedWindow();
+            if (isOptionsDialogShown || owner == null)
             {
                 return;
             }
@@ -448,15 +457,18 @@ namespace BabySmash
             {
                 var options = new Options
                 {
-                    Owner = windows[0],
+                    Owner = owner,
                     Topmost = true
                 };
 
                 Mouse.Capture(null);
-                foreach (MainWindow window in windows)
+                foreach (MainWindow window in windows.Where(window => window.IsLoaded).ToList())
                 {
                     window.Topmost = false;
-                    window.CustomCursor.Visibility = Visibility.Hidden;
+                    if (window.CustomCursor != null)
+                    {
+                        window.CustomCursor.Visibility = Visibility.Hidden;
+                    }
                 }
 
                 options.ShowDialog();
@@ -464,8 +476,14 @@ namespace BabySmash
                 if (transparentBackground != Settings.Default.TransparentBackground)
                 {
                     RestoreKioskStateCore(restoreCursor: false);
+                    owner = GetFirstLoadedWindow();
+                    if (owner == null)
+                    {
+                        return;
+                    }
+
                     MessageBoxResult result = MessageBox.Show(
-                        windows[0],
+                        owner,
                         "You've changed the Window Transparency Option. We'll need to restart BabySmash! for you to see the change. Pressing YES will restart BabySmash!. Is that OK?",
                         "Need to Restart", MessageBoxButton.YesNo, MessageBoxImage.Question);
 
@@ -479,6 +497,11 @@ namespace BabySmash
             finally
             {
                 isOptionsDialogShown = false;
+                foreach (MainWindow window in windows.Where(window => window.IsLoaded).ToList())
+                {
+                    window.ResetOptionsGestureAfterDialog();
+                }
+
                 RestoreKioskStateCore(restoreCursor: true);
             }
         }
@@ -493,8 +516,18 @@ namespace BabySmash
             RestoreKioskStateCore(restoreCursor: false);
         }
 
+        public void CancelOptionsGesture()
+        {
+            PruneClosedWindows();
+            foreach (MainWindow window in windows.Where(window => window.IsLoaded).ToList())
+            {
+                window.CancelOptionsGestureFromHook();
+            }
+        }
+
         private void RestoreKioskStateCore(bool restoreCursor)
         {
+            PruneClosedWindows();
             if (isRestoringKioskState || windows.Count == 0)
             {
                 return;
@@ -503,51 +536,95 @@ namespace BabySmash
             isRestoringKioskState = true;
             try
             {
-                foreach (MainWindow window in windows)
+                foreach (MainWindow window in windows.ToList())
                 {
-                    if (!window.IsLoaded)
+                    if (!windowScreenDeviceNames.TryGetValue(window, out string assignedDeviceName))
                     {
                         continue;
                     }
 
-                    window.WindowStyle = WindowStyle.None;
-                    window.ResizeMode = ResizeMode.NoResize;
-
-                    if (window.WindowState != WindowState.Maximized)
-                    {
-                        WinForms.Screen screen = windowScreens[window];
-                        window.WindowState = WindowState.Normal;
-                        PositionWindowOnScreen(window, screen);
-                        window.WindowState = WindowState.Maximized;
-                    }
-
-                    window.Topmost = true;
-                    if (restoreCursor)
-                    {
-                        window.RestoreCursor();
-                    }
+                    RestoreWindow(window, assignedDeviceName, restoreCursor);
                 }
 
-                MainWindow primaryWindow = windows[0];
-                if (!primaryWindow.IsLoaded)
+                MainWindow primaryWindow = GetFirstLoadedWindow();
+                if (primaryWindow == null)
                 {
                     return;
                 }
 
-                primaryWindow.Activate();
-                Keyboard.Focus(primaryWindow);
-
-                IntPtr windowHandle = new WindowInteropHelper(primaryWindow).Handle;
-                if (windowHandle != IntPtr.Zero)
+                try
                 {
-                    SetForegroundWindow(windowHandle);
-                    SetFocus(windowHandle);
+                    primaryWindow.Activate();
+                    Keyboard.Focus(primaryWindow);
+
+                    IntPtr windowHandle = new WindowInteropHelper(primaryWindow).Handle;
+                    if (windowHandle != IntPtr.Zero)
+                    {
+                        SetForegroundWindow(windowHandle);
+                        SetFocus(windowHandle);
+                    }
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Debug.WriteLine($"Unable to reactivate a BabySmash window during teardown: {ex.Message}");
                 }
             }
             finally
             {
                 isRestoringKioskState = false;
             }
+        }
+
+        private void RestoreWindow(MainWindow window, string assignedDeviceName, bool restoreCursor)
+        {
+            if (!window.IsLoaded)
+            {
+                return;
+            }
+
+            try
+            {
+                WinForms.Screen assignedScreen = ResolveScreen(assignedDeviceName);
+                IntPtr handle = new WindowInteropHelper(window).Handle;
+                bool isOnAssignedScreen = assignedScreen != null &&
+                    string.Equals(
+                        WinForms.Screen.FromHandle(handle).DeviceName,
+                        assignedScreen.DeviceName,
+                        StringComparison.OrdinalIgnoreCase);
+
+                window.WindowStyle = WindowStyle.None;
+                window.ResizeMode = ResizeMode.NoResize;
+
+                if (window.WindowState != WindowState.Maximized || !isOnAssignedScreen)
+                {
+                    window.WindowState = WindowState.Normal;
+                    if (assignedScreen != null)
+                    {
+                        PositionWindowOnScreen(window, assignedScreen);
+                    }
+
+                    window.WindowState = WindowState.Maximized;
+                }
+
+                window.Topmost = true;
+                if (restoreCursor)
+                {
+                    window.RestoreCursor();
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.WriteLine($"Unable to restore {window.Name} during teardown: {ex.Message}");
+            }
+        }
+
+        private static WinForms.Screen ResolveScreen(string deviceName)
+        {
+            WinForms.Screen[] screens = WinForms.Screen.AllScreens;
+            return screens.FirstOrDefault(
+                       screen => string.Equals(screen.DeviceName, deviceName, StringComparison.OrdinalIgnoreCase))
+                   ?? WinForms.Screen.PrimaryScreen
+                   ?? screens.FirstOrDefault();
         }
 
         private static void PositionWindowOnScreen(MainWindow window, WinForms.Screen screen)
@@ -566,6 +643,35 @@ namespace BabySmash
                     $"Failed to position {window.Name} on {screen.DeviceName}: " +
                     new Win32Exception(Marshal.GetLastWin32Error()).Message);
             }
+        }
+
+        private MainWindow GetFirstLoadedWindow()
+        {
+            return windows.FirstOrDefault(window => window.IsLoaded);
+        }
+
+        private void HandleWindowClosed(object sender, EventArgs e)
+        {
+            if (sender is MainWindow window)
+            {
+                RemoveWindow(window);
+            }
+        }
+
+        private void PruneClosedWindows()
+        {
+            foreach (MainWindow window in windows.Where(window => !window.IsLoaded).ToList())
+            {
+                RemoveWindow(window);
+            }
+        }
+
+        private void RemoveWindow(MainWindow window)
+        {
+            window.Closed -= HandleWindowClosed;
+            windows.Remove(window);
+            windowScreenDeviceNames.Remove(window);
+            figuresUserControlQueue.Remove(window.Name);
         }
 
         public void MouseDown(MainWindow main, MouseButtonEventArgs e)

--- a/Controller.cs
+++ b/Controller.cs
@@ -10,6 +10,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using BabySmash.Properties;
+using Microsoft.Win32;
 using Application = System.Windows.Application;
 using Brushes = System.Windows.Media.Brushes;
 using Color = System.Windows.Media.Color;
@@ -58,8 +59,10 @@ namespace BabySmash
         public bool isOptionsDialogShown { get; set; }
         private bool isDrawing = false;
         private readonly List<MainWindow> windows = new List<MainWindow>();
+        private readonly Dictionary<MainWindow, string> windowPreferredScreenDeviceNames = new Dictionary<MainWindow, string>();
         private readonly Dictionary<MainWindow, string> windowScreenDeviceNames = new Dictionary<MainWindow, string>();
         private bool isRestoringKioskState;
+        private bool isSubscribedToDisplayChanges;
         private readonly SpeechQueue _speechQueue = new SpeechQueue(5);
 
         private DispatcherTimer timer = new DispatcherTimer(DispatcherPriority.Normal);
@@ -79,6 +82,8 @@ namespace BabySmash
         {
             timer.Tick += new EventHandler(timer_Tick);
             timer.Interval = new TimeSpan(0, 0, 1);
+            SystemEvents.DisplaySettingsChanged += HandleDisplaySettingsChanged;
+            isSubscribedToDisplayChanges = true;
             int Number = 0;
 
             // TODO: Updatum auto-update will be added here in Phase 6
@@ -106,6 +111,7 @@ namespace BabySmash
 
                 figuresUserControlQueue[m.Name] = new List<UserControl>();
                 windows.Add(m);
+                windowPreferredScreenDeviceNames[m] = s.DeviceName;
                 windowScreenDeviceNames[m] = s.DeviceName;
 
                 m.Show();
@@ -133,7 +139,14 @@ namespace BabySmash
 
         void timer_Tick(object sender, EventArgs e)
         {
-            RestoreKioskState();
+            try
+            {
+                RestoreKioskState();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Kiosk state recovery failed: {ex}");
+            }
         }
 
         public void ProcessKey(FrameworkElement uie, KeyEventArgs e)
@@ -230,13 +243,26 @@ namespace BabySmash
 
         private void AddFigure(FrameworkElement uie, char c)
         {
+            PruneClosedWindows();
             FigureTemplate template = FigureGenerator.GenerateFigureTemplate(c);
-            foreach (MainWindow window in this.windows)
+            var activeWindows = windows
+                .Where(window => window.IsLoaded && figuresUserControlQueue.ContainsKey(window.Name))
+                .ToList();
+            if (activeWindows.Count == 0)
             {
+                return;
+            }
+
+            foreach (MainWindow window in activeWindows)
+            {
+                if (!figuresUserControlQueue.TryGetValue(window.Name, out List<UserControl> queue))
+                {
+                    continue;
+                }
+
                 UserControl f = FigureGenerator.NewUserControlFrom(template);
                 window.AddFigure(f);
 
-                var queue = figuresUserControlQueue[window.Name];
                 queue.Add(f);
 
                 // Letters should already have accurate width and height, but others may them assigned.
@@ -268,12 +294,23 @@ namespace BabySmash
             }
 
             // Find the last word typed, if applicable.
-            string lastWord = this.wordFinder.LastWord(figuresUserControlQueue.Values.First());
+            List<UserControl> firstQueue = activeWindows
+                .Select(window => figuresUserControlQueue.TryGetValue(window.Name, out List<UserControl> queue) ? queue : null)
+                .FirstOrDefault(queue => queue != null);
+            if (firstQueue == null)
+            {
+                return;
+            }
+
+            string lastWord = this.wordFinder.LastWord(firstQueue);
             if (lastWord != null)
             {
-                foreach (MainWindow window in this.windows)
+                foreach (MainWindow window in activeWindows)
                 {
-                    this.wordFinder.AnimateLettersIntoWord(figuresUserControlQueue[window.Name], lastWord);
+                    if (figuresUserControlQueue.TryGetValue(window.Name, out List<UserControl> queue))
+                    {
+                        this.wordFinder.AnimateLettersIntoWord(queue, lastWord);
+                    }
                 }
 
                 SpeakString(lastWord, true);
@@ -439,6 +476,12 @@ namespace BabySmash
         {
             timer.Stop();
             timer.Tick -= timer_Tick;
+            if (isSubscribedToDisplayChanges)
+            {
+                SystemEvents.DisplaySettingsChanged -= HandleDisplaySettingsChanged;
+                isSubscribedToDisplayChanges = false;
+            }
+
             _speechQueue.Dispose();
         }
 
@@ -497,10 +540,7 @@ namespace BabySmash
             finally
             {
                 isOptionsDialogShown = false;
-                foreach (MainWindow window in windows.Where(window => window.IsLoaded).ToList())
-                {
-                    window.ResetOptionsGestureAfterDialog();
-                }
+                owner?.ResetOptionsGestureAfterDialog();
 
                 RestoreKioskStateCore(restoreCursor: true);
             }
@@ -524,6 +564,9 @@ namespace BabySmash
                 window.CancelOptionsGestureFromHook();
             }
         }
+
+        public bool HasActiveOptionsGesture =>
+            windows.Any(window => window.IsLoaded && window.IsOptionsGestureArmed);
 
         private void RestoreKioskStateCore(bool restoreCursor)
         {
@@ -627,6 +670,93 @@ namespace BabySmash
                    ?? screens.FirstOrDefault();
         }
 
+        private void HandleDisplaySettingsChanged(object sender, EventArgs e)
+        {
+            Dispatcher dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null ||
+                dispatcher.HasShutdownStarted ||
+                dispatcher.HasShutdownFinished)
+            {
+                return;
+            }
+
+            try
+            {
+                dispatcher.BeginInvoke(
+                    DispatcherPriority.Normal,
+                    new Action(RebuildDisplayAssignments));
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.WriteLine($"Unable to update display assignments during shutdown: {ex.Message}");
+            }
+        }
+
+        private void RebuildDisplayAssignments()
+        {
+            PruneClosedWindows();
+            var activeWindows = windows.Where(window => window.IsLoaded).ToList();
+            var screens = WinForms.Screen.AllScreens.ToList();
+            if (activeWindows.Count == 0 || screens.Count == 0)
+            {
+                return;
+            }
+
+            var availableScreens = new HashSet<string>(
+                screens.Select(screen => screen.DeviceName),
+                StringComparer.OrdinalIgnoreCase);
+            var assignments = new Dictionary<MainWindow, WinForms.Screen>();
+
+            foreach (MainWindow window in activeWindows)
+            {
+                if (windowPreferredScreenDeviceNames.TryGetValue(window, out string preferredDeviceName))
+                {
+                    WinForms.Screen preferredScreen = screens.FirstOrDefault(
+                        screen => string.Equals(
+                            screen.DeviceName,
+                            preferredDeviceName,
+                            StringComparison.OrdinalIgnoreCase));
+                    if (preferredScreen != null && availableScreens.Remove(preferredScreen.DeviceName))
+                    {
+                        assignments[window] = preferredScreen;
+                    }
+                }
+            }
+
+            foreach (MainWindow window in activeWindows.Where(window => !assignments.ContainsKey(window)))
+            {
+                IntPtr handle = new WindowInteropHelper(window).Handle;
+                WinForms.Screen currentScreen = WinForms.Screen.FromHandle(handle);
+                if (availableScreens.Remove(currentScreen.DeviceName))
+                {
+                    assignments[window] = currentScreen;
+                }
+            }
+
+            foreach (MainWindow window in activeWindows.Where(window => !assignments.ContainsKey(window)))
+            {
+                WinForms.Screen screen = screens.FirstOrDefault(
+                    candidate => availableScreens.Remove(candidate.DeviceName));
+                if (screen != null)
+                {
+                    assignments[window] = screen;
+                }
+            }
+
+            int fallbackIndex = 0;
+            foreach (MainWindow window in activeWindows.Where(window => !assignments.ContainsKey(window)))
+            {
+                assignments[window] = screens[fallbackIndex++ % screens.Count];
+            }
+
+            foreach ((MainWindow window, WinForms.Screen screen) in assignments)
+            {
+                windowScreenDeviceNames[window] = screen.DeviceName;
+            }
+
+            RestoreKioskState();
+        }
+
         private static void PositionWindowOnScreen(MainWindow window, WinForms.Screen screen)
         {
             IntPtr handle = new WindowInteropHelper(window).Handle;
@@ -670,6 +800,7 @@ namespace BabySmash
         {
             window.Closed -= HandleWindowClosed;
             windows.Remove(window);
+            windowPreferredScreenDeviceNames.Remove(window);
             windowScreenDeviceNames.Remove(window);
             figuresUserControlQueue.Remove(window.Name);
         }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -18,14 +18,6 @@
         </Storyboard>
     </Window.Resources>
 
-    <Window.CommandBindings>
-        <CommandBinding Command="Properties" Executed="Properties_Executed"/>
-    </Window.CommandBindings>
-    
-    <Window.InputBindings>
-        <KeyBinding Gesture="CTRL+ALT+SHIFT+O" Command="{x:Static ApplicationCommands.Properties}" />
-    </Window.InputBindings>
-
     <Window.Triggers>
         <EventTrigger RoutedEvent="FrameworkElement.Loaded">
             <BeginStoryboard Storyboard="{StaticResource Timeline1}"/>
@@ -87,7 +79,7 @@
                 </TextBlock.BitmapEffect>
             <Bold>BabySmash!</Bold> by Scott Hanselman <Italic>with community contributions!</Italic> - http://www.babysmash.com 
             <LineBreak/>
-            <Bold>Ctrl-Shift-Alt-O</Bold> for options, <Bold>ALT-F4</Bold> to exit
+            Hold <Bold>Ctrl-Shift-Alt-O for 3 seconds</Bold> for options, <Bold>ALT-F4</Bold> to exit
             </TextBlock>
             <TextBlock x:Name="UpdateAvailableLabel" Visibility="Hidden" Margin="15,10,0,0" FontSize="12">
                 <TextBlock.BitmapEffect>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -205,14 +205,27 @@ namespace BabySmash
         protected override void OnActivated(EventArgs e)
         {
             base.OnActivated(e);
-            ResetOptionsGestureAfterDialog();
+            if (optionsGestureStopwatch.IsRunning || optionsGestureRequiresRelease)
+            {
+                ResetOptionsGestureAfterDialog();
+            }
+            else
+            {
+                pressedKeys.Clear();
+            }
         }
 
         protected override void OnDeactivated(EventArgs e)
         {
+            bool gestureWasActive = optionsGestureStopwatch.IsRunning || optionsGestureRequiresRelease;
             ResetOptionsGesture();
-            optionsGestureRequiresRelease = true;
             pressedKeys.Clear();
+            if (gestureWasActive && !IsOptionsGestureReleased())
+            {
+                optionsGestureRequiresRelease = true;
+                optionsGestureTimer.Start();
+            }
+
             base.OnDeactivated(e);
         }
 
@@ -317,8 +330,13 @@ namespace BabySmash
 
         internal void CancelOptionsGestureFromHook()
         {
-            CancelOptionsGestureUntilRelease();
+            if (optionsGestureStopwatch.IsRunning)
+            {
+                CancelOptionsGestureUntilRelease();
+            }
         }
+
+        internal bool IsOptionsGestureArmed => optionsGestureStopwatch.IsRunning;
 
         private void CancelOptionsGestureUntilRelease()
         {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Cursors = System.Windows.Input.Cursors;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MouseEventArgs = System.Windows.Input.MouseEventArgs;
@@ -16,6 +17,10 @@ namespace BabySmash
     {
         private readonly Controller controller;
         public Controller Controller { get { return controller; } }
+        private static readonly ModifierKeys OptionsModifiers = ModifierKeys.Control | ModifierKeys.Alt | ModifierKeys.Shift;
+        private readonly DispatcherTimer optionsGestureTimer;
+        private bool optionsGestureReady = true;
+        private bool suppressOptionsKeyUp;
 
         private UserControl customCursor;
         public UserControl CustomCursor { get { return customCursor; } set { customCursor = value; } }
@@ -42,6 +47,12 @@ namespace BabySmash
             _showFps = showFps;
             InitializeComponent();
 
+            optionsGestureTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(3)
+            };
+            optionsGestureTimer.Tick += OptionsGestureTimer_Tick;
+
             // Initialize cursor early to prevent NullReferenceException in mouse events (OnMouseEnter, OnMouseLeave, OnMouseMove)
             AssertCursor();
 
@@ -67,6 +78,9 @@ namespace BabySmash
 
         protected override void OnClosed(EventArgs e)
         {
+            optionsGestureTimer.Stop();
+            optionsGestureTimer.Tick -= OptionsGestureTimer_Tick;
+
             if (_showFps)
             {
                 CompositionTarget.Rendering -= OnRendering;
@@ -125,8 +139,59 @@ namespace BabySmash
         protected override void OnKeyUp(KeyEventArgs e)
         {
             base.OnKeyUp(e);
+
+            Key key = e.Key == Key.System ? e.SystemKey : e.Key;
+            if (IsOptionsGestureKey(key) &&
+                (optionsGestureTimer.IsEnabled || !optionsGestureReady || suppressOptionsKeyUp))
+            {
+                optionsGestureTimer.Stop();
+                if (IsOptionsGestureReleased())
+                {
+                    suppressOptionsKeyUp = false;
+                    optionsGestureReady = true;
+                }
+
+                e.Handled = true;
+                return;
+            }
+
             e.Handled = true;
             controller.ProcessKey(this, e);
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            base.OnKeyDown(e);
+
+            Key key = e.Key == Key.System ? e.SystemKey : e.Key;
+            if (key == Key.O && Keyboard.Modifiers == OptionsModifiers)
+            {
+                if (optionsGestureReady && !optionsGestureTimer.IsEnabled)
+                {
+                    suppressOptionsKeyUp = true;
+                    optionsGestureTimer.Start();
+                }
+
+                e.Handled = true;
+                return;
+            }
+
+            if (optionsGestureTimer.IsEnabled && !IsOptionsModifier(key))
+            {
+                optionsGestureTimer.Stop();
+            }
+        }
+
+        protected override void OnStateChanged(EventArgs e)
+        {
+            base.OnStateChanged(e);
+
+            if (IsLoaded && !controller.isOptionsDialogShown)
+            {
+                Dispatcher.BeginInvoke(
+                    DispatcherPriority.ApplicationIdle,
+                    new Action(() => controller.RestoreKioskState()));
+            }
         }
 
         protected override void OnLostMouseCapture(MouseEventArgs e)
@@ -156,9 +221,54 @@ namespace BabySmash
             }
         }
 
-        private void Properties_Executed(object sender, ExecutedRoutedEventArgs e)
+        internal void RestoreCursor()
         {
-            controller.ShowOptionsDialog();
+            AssertCursor();
+            Cursor = Cursors.None;
+
+            Point position = Mouse.GetPosition(mouseDragCanvas);
+            Canvas.SetTop(CustomCursor, position.Y);
+            Canvas.SetLeft(CustomCursor, position.X);
+            Canvas.SetZIndex(CustomCursor, int.MaxValue);
+            CustomCursor.Visibility = IsMouseOver ? Visibility.Visible : Visibility.Hidden;
+        }
+
+        private void OptionsGestureTimer_Tick(object sender, EventArgs e)
+        {
+            optionsGestureTimer.Stop();
+
+            if (optionsGestureReady &&
+                Keyboard.Modifiers == OptionsModifiers &&
+                Keyboard.IsKeyDown(Key.O))
+            {
+                optionsGestureReady = false;
+                controller.ShowOptionsDialog();
+
+                if (IsOptionsGestureReleased())
+                {
+                    suppressOptionsKeyUp = false;
+                    optionsGestureReady = true;
+                }
+            }
+        }
+
+        private static bool IsOptionsGestureKey(Key key)
+        {
+            return key == Key.O ||
+                   key == Key.LeftCtrl || key == Key.RightCtrl ||
+                   key == Key.LeftAlt || key == Key.RightAlt ||
+                   key == Key.LeftShift || key == Key.RightShift;
+        }
+
+        private static bool IsOptionsModifier(Key key)
+        {
+            return IsOptionsGestureKey(key) && key != Key.O;
+        }
+
+        private static bool IsOptionsGestureReleased()
+        {
+            return !Keyboard.IsKeyDown(Key.O) &&
+                   (Keyboard.Modifiers & OptionsModifiers) == ModifierKeys.None;
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -17,10 +18,19 @@ namespace BabySmash
     {
         private readonly Controller controller;
         public Controller Controller { get { return controller; } }
-        private static readonly ModifierKeys OptionsModifiers = ModifierKeys.Control | ModifierKeys.Alt | ModifierKeys.Shift;
+        private const int VkShift = 0x10;
+        private const int VkControl = 0x11;
+        private const int VkMenu = 0x12;
+        private const int VkLeftWindows = 0x5B;
+        private const int VkRightWindows = 0x5C;
+        private const int VkO = 0x4F;
         private readonly DispatcherTimer optionsGestureTimer;
-        private bool optionsGestureReady = true;
-        private bool suppressOptionsKeyUp;
+        private readonly Stopwatch optionsGestureStopwatch = new();
+        private readonly HashSet<Key> pressedKeys = new();
+        private bool optionsGestureRequiresRelease;
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int virtualKey);
 
         private UserControl customCursor;
         public UserControl CustomCursor { get { return customCursor; } set { customCursor = value; } }
@@ -47,9 +57,9 @@ namespace BabySmash
             _showFps = showFps;
             InitializeComponent();
 
-            optionsGestureTimer = new DispatcherTimer
+            optionsGestureTimer = new DispatcherTimer(DispatcherPriority.Input)
             {
-                Interval = TimeSpan.FromSeconds(3)
+                Interval = TimeSpan.FromMilliseconds(50)
             };
             optionsGestureTimer.Tick += OptionsGestureTimer_Tick;
 
@@ -78,7 +88,7 @@ namespace BabySmash
 
         protected override void OnClosed(EventArgs e)
         {
-            optionsGestureTimer.Stop();
+            ResetOptionsGesture();
             optionsGestureTimer.Tick -= OptionsGestureTimer_Tick;
 
             if (_showFps)
@@ -141,14 +151,13 @@ namespace BabySmash
             base.OnKeyUp(e);
 
             Key key = e.Key == Key.System ? e.SystemKey : e.Key;
+            pressedKeys.Remove(key);
             if (IsOptionsGestureKey(key) &&
-                (optionsGestureTimer.IsEnabled || !optionsGestureReady || suppressOptionsKeyUp))
+                (optionsGestureStopwatch.IsRunning || optionsGestureRequiresRelease))
             {
-                optionsGestureTimer.Stop();
                 if (IsOptionsGestureReleased())
                 {
-                    suppressOptionsKeyUp = false;
-                    optionsGestureReady = true;
+                    ResetOptionsGesture();
                 }
 
                 e.Handled = true;
@@ -164,11 +173,22 @@ namespace BabySmash
             base.OnKeyDown(e);
 
             Key key = e.Key == Key.System ? e.SystemKey : e.Key;
-            if (key == Key.O && Keyboard.Modifiers == OptionsModifiers)
+            pressedKeys.Add(key);
+            if (optionsGestureRequiresRelease)
             {
-                if (optionsGestureReady && !optionsGestureTimer.IsEnabled)
+                if (IsOptionsGestureKey(key))
                 {
-                    suppressOptionsKeyUp = true;
+                    e.Handled = true;
+                }
+
+                return;
+            }
+
+            if (key == Key.O && IsExactOptionsGestureHeld())
+            {
+                if (!optionsGestureStopwatch.IsRunning)
+                {
+                    optionsGestureStopwatch.Restart();
                     optionsGestureTimer.Start();
                 }
 
@@ -176,10 +196,24 @@ namespace BabySmash
                 return;
             }
 
-            if (optionsGestureTimer.IsEnabled && !IsOptionsModifier(key))
+            if (optionsGestureStopwatch.IsRunning)
             {
-                optionsGestureTimer.Stop();
+                CancelOptionsGestureUntilRelease();
             }
+        }
+
+        protected override void OnActivated(EventArgs e)
+        {
+            base.OnActivated(e);
+            ResetOptionsGestureAfterDialog();
+        }
+
+        protected override void OnDeactivated(EventArgs e)
+        {
+            ResetOptionsGesture();
+            optionsGestureRequiresRelease = true;
+            pressedKeys.Clear();
+            base.OnDeactivated(e);
         }
 
         protected override void OnStateChanged(EventArgs e)
@@ -189,7 +223,7 @@ namespace BabySmash
             if (IsLoaded && !controller.isOptionsDialogShown)
             {
                 Dispatcher.BeginInvoke(
-                    DispatcherPriority.ApplicationIdle,
+                    DispatcherPriority.Normal,
                     new Action(() => controller.RestoreKioskState()));
             }
         }
@@ -226,6 +260,11 @@ namespace BabySmash
             AssertCursor();
             Cursor = Cursors.None;
 
+            if (CustomCursor == null)
+            {
+                return;
+            }
+
             Point position = Mouse.GetPosition(mouseDragCanvas);
             Canvas.SetTop(CustomCursor, position.Y);
             Canvas.SetLeft(CustomCursor, position.X);
@@ -235,21 +274,64 @@ namespace BabySmash
 
         private void OptionsGestureTimer_Tick(object sender, EventArgs e)
         {
-            optionsGestureTimer.Stop();
-
-            if (optionsGestureReady &&
-                Keyboard.Modifiers == OptionsModifiers &&
-                Keyboard.IsKeyDown(Key.O))
+            if (optionsGestureRequiresRelease)
             {
-                optionsGestureReady = false;
-                controller.ShowOptionsDialog();
-
                 if (IsOptionsGestureReleased())
                 {
-                    suppressOptionsKeyUp = false;
-                    optionsGestureReady = true;
+                    ResetOptionsGesture();
                 }
+
+                return;
             }
+
+            if (!optionsGestureStopwatch.IsRunning)
+            {
+                optionsGestureTimer.Stop();
+                return;
+            }
+
+            if (!IsExactOptionsGestureHeld())
+            {
+                CancelOptionsGestureUntilRelease();
+                return;
+            }
+
+            if (optionsGestureStopwatch.Elapsed >= TimeSpan.FromSeconds(3))
+            {
+                optionsGestureStopwatch.Reset();
+                optionsGestureTimer.Stop();
+                optionsGestureRequiresRelease = true;
+                controller.ShowOptionsDialog();
+            }
+        }
+
+        internal void ResetOptionsGestureAfterDialog()
+        {
+            ResetOptionsGesture();
+            optionsGestureRequiresRelease = !IsOptionsGestureReleased();
+            if (optionsGestureRequiresRelease)
+            {
+                optionsGestureTimer.Start();
+            }
+        }
+
+        internal void CancelOptionsGestureFromHook()
+        {
+            CancelOptionsGestureUntilRelease();
+        }
+
+        private void CancelOptionsGestureUntilRelease()
+        {
+            optionsGestureStopwatch.Reset();
+            optionsGestureRequiresRelease = true;
+            optionsGestureTimer.Start();
+        }
+
+        private void ResetOptionsGesture()
+        {
+            optionsGestureStopwatch.Reset();
+            optionsGestureTimer.Stop();
+            optionsGestureRequiresRelease = false;
         }
 
         private static bool IsOptionsGestureKey(Key key)
@@ -260,15 +342,28 @@ namespace BabySmash
                    key == Key.LeftShift || key == Key.RightShift;
         }
 
-        private static bool IsOptionsModifier(Key key)
+        private bool IsExactOptionsGestureHeld()
         {
-            return IsOptionsGestureKey(key) && key != Key.O;
+            return IsKeyDown(VkO) &&
+                   IsKeyDown(VkControl) &&
+                   IsKeyDown(VkMenu) &&
+                   IsKeyDown(VkShift) &&
+                   !IsKeyDown(VkLeftWindows) &&
+                   !IsKeyDown(VkRightWindows) &&
+                   pressedKeys.All(IsOptionsGestureKey);
         }
 
         private static bool IsOptionsGestureReleased()
         {
-            return !Keyboard.IsKeyDown(Key.O) &&
-                   (Keyboard.Modifiers & OptionsModifiers) == ModifierKeys.None;
+            return !IsKeyDown(VkO) &&
+                   !IsKeyDown(VkControl) &&
+                   !IsKeyDown(VkMenu) &&
+                   !IsKeyDown(VkShift);
+        }
+
+        private static bool IsKeyDown(int virtualKey)
+        {
+            return (GetAsyncKeyState(virtualKey) & 0x8000) != 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the instant `Ctrl+Alt+Shift+O` binding with an exact three-second hold gesture
- sticky-cancel only an actively armed gesture when any unrelated key is pressed, including keys consumed by the low-level hook; ordinary `O` and modifier smashing still creates gameplay shapes
- restore every BabySmash window to a unique current display in maximized, borderless, topmost kiosk mode after Options, window-state, or display-topology transitions
- preserve preferred display ownership across temporary disconnects while resolving current bounds dynamically and falling back safely
- restore foreground focus and the custom cursor after modal dialogs while safely handling window teardown
- preserve the low-level keyboard-hook policy and reliable `Alt+F4` exit, including shutdown-time input

## Build
- `dotnet build BabySmash.csproj -c Release --no-restore`
- succeeded with 0 warnings and 0 errors

## Manual Windows smoke test

### One monitor
- [ ] Launch BabySmash and confirm it is borderless, maximized, topmost, and covers the desktop.
- [ ] Randomly smash letters and modifiers for at least two minutes; confirm normal `O`, Ctrl/Shift combinations, and unrelated repeating keys still create shapes, Options never opens accidentally, and the app never becomes windowed.
- [ ] Tap `Ctrl+Alt+Shift+O`, then hold it for less than three seconds; confirm Options does not open.
- [ ] Hold exactly `Ctrl+Alt+Shift+O` for three seconds; confirm Options opens once.
- [ ] During an armed hold with `O` repeating, press an unrelated letter and separately a blocked key such as `Tab`; confirm cancellation occurs only for that armed hold and remains sticky until the entire chord is released.
- [ ] After cancellation, resume ordinary letters/modifiers; confirm their shapes still appear.
- [ ] Open Options repeatedly, releasing Alt last after each close; confirm every subsequent full hold opens once.
- [ ] Close Options with OK, Cancel, and Escape; confirm borderless/maximized/topmost state, focus, and custom cursor restore each time.
- [ ] Press `Alt+F4` while Options is open and while smashing keys during shutdown; confirm a clean exit without dispatcher errors.
- [ ] Force a window-state change and primary-window teardown with debugging/automation; confirm recovery or shutdown does not crash.
- [ ] Confirm `Alt+Tab`, `Alt+Space`, and the Windows key remain blocked.

### Four monitors
- [ ] Launch with four displays, including mixed DPI/scaling if available; confirm one borderless maximized window covers each monitor.
- [ ] Repeat ordinary gameplay, active-hold cancellation, repeated Options-open, and Alt-released-last tests from each focused window.
- [ ] Close Options with OK, Cancel, and Escape; confirm all windows return topmost/maximized on unique displays with no other app exposed.
- [ ] Force a maximized window onto the wrong display; confirm it returns to its assigned display.
- [ ] Put one monitor to sleep or disconnect it; confirm remaining active displays stay uniquely covered where enough windows exist and no windows all stack on primary.
- [ ] Wake/reconnect and, if Windows renumbers displays, confirm assignments rebuild uniquely and the preferred window returns when its prior device identity is available.
- [ ] Change display arrangement or scaling; confirm current bounds are used rather than stale coordinates.
- [ ] Change transparency, choose No at the restart prompt, and confirm all windows recover.

Adding a brand-new monitor while BabySmash is already running does not create an additional game window; restart BabySmash to cover newly added displays.

Do not merge until the one- and four-monitor kiosk checks above are completed on Windows.

Fixes #111